### PR TITLE
fix packege name

### DIFF
--- a/netdata/netdata.sls
+++ b/netdata/netdata.sls
@@ -36,7 +36,7 @@ netdata_depencies_installed:
     {%- if grains['os'] in ['Ubuntu', 'Debian'] %}
       - zlib1g-dev
       - uuid-dev
-      - netcat
+      - netcat-openbsd
       - pkg-config
       - libuuid1
       - zlib1g


### PR DESCRIPTION
07:54:22 bg:0 root@dev-*.*.com:/# netcat
This is nc from the netcat-openbsd package. An alternative nc is available
in the netcat-traditional package.

```
          ID: netdata_depencies_installed
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 07:48:15.439465
    Duration: 26.671 ms
     Changes:   
    Warnings: The following package(s) are "virtual package" names: netcat.
              These will no longer be supported as of the Fluorine release.
              Please update your SLS file(s) to use the actual package name.


```