### PR TITLE
fix pkg insstall in debian 10

### DIFF
--- a/cloud/pkg.sls
+++ b/cloud/pkg.sls
@@ -49,7 +49,7 @@ pkg_deb_packages:
       - at
       - doc-debian
       - ftp
-  {%- if grains['oscodename'] == 'bionic' %}
+  {%- if grains['oscodename'] in ['bionic', 'buster'] %}
       - bind9-host
   {%- else %}
       - host
@@ -167,7 +167,9 @@ pkg_deb_packages:
       # build tools
       - build-essential
       - git
+  {%- if grains['oscodename'] != 'buster' %}
       - checkinstall
+  {%- endif %}
       # test tools
       - memtester
       - bonnie++


### PR DESCRIPTION
1.
         ID: pkg_deb_packages
    Function: pkg.installed
      Result: False
     Comment: The following packages failed to install/update: host
              84 targeted packages were already installed
     Started: 23:12:16.663108
    Duration: 251.044 ms
2. 
          ID: pkg_deb_packages
    Function: pkg.installed
      Result: False
     Comment: Problem encountered installing package(s). Additional info follows:
              
              errors:
                  - Running scope as unit: run-r41e6097fc95b4ce1b5ed496d3728e58e.scope
                    E: Unable to locate package checkinstall