### PR TITLE
Update php config path detection

### DIFF
--- a/app/php-fpm_apps.sls
+++ b/app/php-fpm_apps.sls
@@ -513,21 +513,9 @@ php-fpm_apps_app_nginx_vhost_config_{{ loop.index }}:
         {%- endif %}
 
         {%- set php_admin = app_params['pool'].get('php_admin', '; no other admin vals') %}
-        {%- if (app_params['pool']['php_version'] == '5.6' ) %}
-          {%- set etc_php = '/etc/php/5.6/' %}
-        {%- elif (app_params['pool']['php_version'] == '7.0' ) %}
-          {%- set etc_php = '/etc/php/7.0/' %}
-        {%- elif (app_params['pool']['php_version'] == '7.1' ) %}
-          {%- set etc_php = '/etc/php/7.1/' %}
-        {%- elif (app_params['pool']['php_version'] == '7.2' ) %}
-          {%- set etc_php = '/etc/php/7.2/' %}
-        {%- elif (app_params['pool']['php_version'] == '7.3' ) %}
-          {%- set etc_php = '/etc/php/7.3/' %}
-        {%- elif (app_params['pool']['php_version'] == '7.4' ) %}
-          {%- set etc_php = '/etc/php/7.4/' %}
-        {%- elif (app_params['pool']['php_version'] == '5.5' ) %}
-          {%- set etc_php = '/etc/php5/' %}
-        {%- endif %}
+
+        {%- set etc_php = '/etc/php/' ~ app_params['pool']['php_version'] ~ '/' %}
+
 php-fpm_apps_app_pool_config_{{ loop.index }}:
   file.managed:
     - name: '{{ etc_php }}/fpm/pool.d/{{ phpfpm_app }}.conf'


### PR DESCRIPTION
- After php5 seems all php versions are using the same etc config
path, so we should not worry about different path each version
- Also dropped support for php5.5, (not php5.6)