### PR TITLE
fix for xwiki tomcat https proxy

### DIFF
--- a/xwiki/init.sls
+++ b/xwiki/init.sls
@@ -259,7 +259,7 @@ xwiki_oidc_skipped_{{ loop.index }}:
 
 xwiki_tomcat_https_proxy_fix_{{ loop.index }}:
   cmd.run:
-    - name: docker exec -it xwiki-{{ domain["name"] }} bash -c 'sed -ie "s/<Connector port=\"8080\" protocol=\"HTTP\/1.1\" *$/<Connector port=\"8080\" protocol=\"HTTP\/1.1\" scheme=\"https\"/g" /usr/local/tomcat/conf/server.xml'
+    - name: docker exec -i xwiki-{{ domain["name"] }} bash -c 'sed -ie "s/<Connector port=\"8080\" protocol=\"HTTP\/1.1\" *$/<Connector port=\"8080\" protocol=\"HTTP\/1.1\" scheme=\"https\"/g" /usr/local/tomcat/conf/server.xml'
 
 xwiki_container_restart_{{ loop.index }}:
   cmd.run:

--- a/xwiki/init.sls
+++ b/xwiki/init.sls
@@ -257,6 +257,10 @@ xwiki_oidc_skipped_{{ loop.index }}:
 
   {%- endif %}
 
+xwiki_tomcat_https_proxy_fix_{{ loop.index }}:
+  cmd.run:
+    - name: docker exec -it xwiki-{{ domain["name"] }} bash -c 'sed -ie "s/<Connector port=\"8080\" protocol=\"HTTP\/1.1\" *$/<Connector port=\"8080\" protocol=\"HTTP\/1.1\" scheme=\"https\"/g" /usr/local/tomcat/conf/server.xml'
+
 xwiki_container_restart_{{ loop.index }}:
   cmd.run:
     - name: docker stop xwiki-{{ domain["name"] }} && docker start xwiki-{{ domain["name"] }}


### PR DESCRIPTION
Firefox cant edit Pages over HTTPS due to the error - "**Failed to lock the page**".

to fix it, in the file /usr/local/tomcat/conf/server.xml need to replace the string

`Connector port = "8080" protocol = "HTTP / 1.1"`

on the

`Connector port = "8080" protocol = "HTTP / 1.1" scheme = "https"`