### PR TITLE
Fix .ssh, .ssh/authorized_keys management

### DIFF
--- a/app/php-fpm_apps.sls
+++ b/app/php-fpm_apps.sls
@@ -58,11 +58,11 @@
                (app_selector == phpfpm_app)
              )
       %}
+{%- if ( app_params['keep_user'] is not defined ) or ( app_params['keep_user'] is defined and app_params['keep_user'] != True ) %}
 php-fpm_apps_group_{{ loop.index }}:
   group.present:
     - name: {{ app_params['group'] }}
 
-{% if ( app_params['keep_user'] is not defined ) or ( app_params['keep_user'] is defined and app_params['keep_user'] != True ) %}
 php-fpm_apps_user_{{ loop.index }}:
   user.present:
     - name: {{ app_params['user'] }}
@@ -84,7 +84,6 @@ php-fpm_apps_user_{{ loop.index }}:
     {%- endif %}
     - shell: {{ app_params['shell'] }}
     - fullname: {{ 'application ' ~ phpfpm_app }}
-{%- endif %}
 
 php-fpm_apps_user_ssh_dir_{{ loop.index }}:
   file.directory:
@@ -103,6 +102,7 @@ php-fpm_apps_user_ssh_auth_keys_{{ loop.index }}:
     - mode: 600
     - contents: {{ app_params['app_auth_keys'] | yaml_encode }}
         {%- endif %}
+{%- endif %}
 
         {%- if
                (app_params['source'] is defined) and (app_params['source'] is not none) and

--- a/app/python_apps.sls
+++ b/app/python_apps.sls
@@ -56,16 +56,13 @@ Salt minion 3001+ with python3-pip deb package required for virtualenv.managed t
                (app_selector == python_app)
              )
       %}
+
+
+{%- if ( app_params['keep_user'] is not defined ) or ( app_params['keep_user'] is defined and app_params['keep_user'] != True ) %}
 python_apps_group_{{ loop.index }}:
   group.present:
     - name: {{ app_params['group'] }}
 
-python_apps_user_homedir_{{ loop.index }}:
-  file.directory:
-    - name: {{ app_params['app_root'] }}
-    - makedirs: True
-
-{% if ( app_params['keep_user'] is not defined ) or ( app_params['keep_user'] is defined and app_params['keep_user'] != True ) %}
 python_apps_user_{{ loop.index }}:
   user.present:
     - name: {{ app_params['user'] }}
@@ -87,22 +84,6 @@ python_apps_user_{{ loop.index }}:
     {%- endif %}
     - shell: {{ app_params['shell'] }}
     - fullname: {{ 'application ' ~ python_app }}
-{%- endif %}
-
-python_apps_user_homedir_userown_{{ loop.index }}:
-  file.directory:
-    - name: {{ app_params['app_root'] }}
-    - user: {{ app_params['user'] }}
-    - group: {{ app_params['group'] }}
-    - makedirs: True
-
-python_apps_nginx_root_dir_{{ loop.index }}:
-  file.directory:
-    - name: {{ app_params['nginx']['root'] }}
-    - user: {{ app_params['user'] }}
-    - group: {{ app_params['group'] }}
-    - mode: 755
-    - makedirs: True
 
 python_apps_user_ssh_dir_{{ loop.index }}:
   file.directory:
@@ -121,6 +102,15 @@ python_apps_user_ssh_auth_keys_{{ loop.index }}:
     - mode: 600
     - contents: {{ app_params['app_auth_keys'] | yaml_encode }}
         {%- endif %}
+{%- endif %}
+
+python_apps_nginx_root_dir_{{ loop.index }}:
+  file.directory:
+    - name: {{ app_params['nginx']['root'] }}
+    - user: {{ app_params['user'] }}
+    - group: {{ app_params['group'] }}
+    - mode: 755
+    - makedirs: True
 
         {%- if
                (app_params['source'] is defined) and (app_params['source'] is not none) and

--- a/app/static_apps.sls
+++ b/app/static_apps.sls
@@ -54,11 +54,15 @@
                (app_selector == static_app)
              )
       %}
+
+
+
+
+{%- if ( app_params['keep_user'] is not defined ) or ( app_params['keep_user'] is defined and app_params['keep_user'] != True ) %}
 static_apps_group_{{ loop.index }}:
   group.present:
     - name: {{ app_params['group'] }}
 
-{% if ( app_params['keep_user'] is not defined ) or ( app_params['keep_user'] is defined and app_params['keep_user'] != True ) %}
 static_apps_user_{{ loop.index }}:
   user.present:
     - name: {{ app_params['user'] }}
@@ -80,15 +84,6 @@ static_apps_user_{{ loop.index }}:
     {%- endif %}
     - shell: {{ app_params['shell'] }}
     - fullname: {{ 'application ' ~ static_app }}
-{% endif %}
-
-static_apps_nginx_root_dir_{{ loop.index }}:
-  file.directory:
-    - name: {{ app_params['nginx']['root'] }}
-    - user: {{ app_params['user'] }}
-    - group: {{ app_params['group'] }}
-    - mode: 755
-    - makedirs: True
 
 static_apps_user_ssh_dir_{{ loop.index }}:
   file.directory:
@@ -107,6 +102,7 @@ static_apps_user_ssh_auth_keys_{{ loop.index }}:
     - mode: 600
     - contents: {{ app_params['app_auth_keys'] | yaml_encode }}
         {%- endif %}
+{%- endif %}
 
         {%- if
                (app_params['source'] is defined) and (app_params['source'] is not none) and
@@ -125,6 +121,15 @@ static_apps_app_download_arc_{{ loop.index }}:
     - if_missing: {{ app_params['source']['if_missing'] }}
           {%- endif %}
         {%- endif %}
+
+# this creates if_missing dir usually, so it should be after download_arc
+static_apps_nginx_root_dir_{{ loop.index }}:
+  file.directory:
+    - name: {{ app_params['nginx']['root'] }}
+    - user: {{ app_params['user'] }}
+    - group: {{ app_params['group'] }}
+    - mode: 755
+    - makedirs: True
 
         {%- if
                (app_params['source'] is defined) and (app_params['source'] is not none) and


### PR DESCRIPTION
Изначально задача была отключить создание/управление .ssh/authorized_keys
для пилларов где проставлен keep_user: True

для python_apps:
  - удалён блок python_apps_user_homedir т.к. создание домашней папочки для юзера
      управляется в user.present
  - удалёт блок python_apps_user_homedir_userown. Судя по коду - это была затычка для python_apps_user_homedir
      т.к. тот создавал просто папку, без пермишнов юзеру.
      Ну и опять таки, создание и управление домашней директорией пользователей должно быть в user.present

для static_apps:
  - по примеру php-fpm_apps блок создания nginx_root сдвинулся ниже static_apps_app_download_arc
      (archive.extracted)

для всех вместе:
  - если проставлен флаг keep_user: True
    - не создаются:
      - $app_root/.ssh
      - $app_root/.ssh/authorized_keys
    - не создаётся группа (group.present)
  - всё управление настройками юзера должно быть через, например: pillar/user/username.sls