### PR TITLE
Update lxd state

### DIFF
--- a/lxd/instances.sls
+++ b/lxd/instances.sls
@@ -57,7 +57,7 @@ lxd_start_{{ loop.index }}:
 lxd_wait_{{ loop.index }}:
   cmd.run:
     - prepend_path: /snap/bin
-    - name: timeout -v 30s bash -c "until lxc exec {{ instance_name }} true; do sleep 1; done"
+    - name: timeout 30s bash -c "until lxc exec {{ instance_name }} true; do sleep 1; done"
       {%- endif %}
 
       {%- if "bootstrap" in instance_val %}

--- a/lxd/pillar.example
+++ b/lxd/pillar.example
@@ -61,7 +61,7 @@ lxd:
       bootstrap: # focal without fixed mac on eth0
         - focal_network.sh:
           - 111.111.111.111
-          - 255.255.255.0
+          - 24
           - 111.111.111.100
           - '[8.8.8.8, 8.8.4.4, 1.1.1.1, 1.0.0.1]' # '[]' - netplan yaml syntax
           - '[example.com]'
@@ -76,7 +76,7 @@ lxd:
       bootstrap: # focal with fixed mac on eth0
         - focal_network_mac.sh:
           - 111.111.111.111
-          - 255.255.255.0
+          - 24
           - 111.111.111.100
           - '[8.8.8.8, 8.8.4.4, 1.1.1.1, 1.0.0.1]'
           - '[example.com]'
@@ -92,7 +92,7 @@ lxd:
       bootstrap: # focal without fixed mac on eth0 with eth1
         - focal_network_two_nets.sh:
           - 111.111.111.111
-          - 255.255.255.0
+          - 24
           - 111.111.111.100
           - '[8.8.8.8, 8.8.4.4, 1.1.1.1, 1.0.0.1]'
           - '[example.com]'
@@ -109,7 +109,7 @@ lxd:
       bootstrap: # focal with fixed mac on eth0 with eth1
         - focal_network_two_nets_mac.sh:
           - 111.111.111.111
-          - 255.255.255.0
+          - 24
           - 111.111.111.100
           - '[8.8.8.8, 8.8.4.4, 1.1.1.1, 1.0.0.1]'
           - '[example.com]'


### PR DESCRIPTION
- у timeout версии 8.28 нет параметра -v (ubuntu 18.04)
- у focal_network_* вторым параметром должен быть cidr а не netmask