### PR TITLE
Fix nginx vhosts

### DIFF
--- a/app/files/static/vhost.conf
+++ b/app/files/static/vhost.conf
@@ -35,7 +35,8 @@ server {
     location ~ /\.                          { access_log off; log_not_found off; deny all; }
     location ~ ~$                           { access_log off; log_not_found off; deny all; }
 
-    location ~* ^.+\.(jpg|jpeg|gif|png|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|js|flv|swf|svg|woff|woff2|eot)$ {
+    location / {
+        try_files $uri =404;
         expires max;
         access_log off;
         log_not_found off;

--- a/app/files/static/vhost_nocache.conf
+++ b/app/files/static/vhost_nocache.conf
@@ -35,7 +35,8 @@ server {
     location ~ /\.                          { access_log off; log_not_found off; deny all; }
     location ~ ~$                           { access_log off; log_not_found off; deny all; }
 
-    location ~* ^.+\.(jpg|jpeg|gif|png|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|js|flv|swf|svg|woff|woff2|eot)$ {
+    location / {
+        try_files $uri =404;
         expires 1s;
         add_header Cache-Control no-cache;
         access_log off;

--- a/app/files/static/vhost_nocache_nodefault.conf
+++ b/app/files/static/vhost_nocache_nodefault.conf
@@ -24,7 +24,8 @@ server {
     location ~ /\.                          { access_log off; log_not_found off; deny all; }
     location ~ ~$                           { access_log off; log_not_found off; deny all; }
 
-    location ~* ^.+\.(jpg|jpeg|gif|png|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|js|flv|swf|svg|woff|woff2|eot)$ {
+    location / {
+        try_files $uri =404;
         expires 1s;
         add_header Cache-Control no-cache;
         access_log off;

--- a/app/files/static/vhost_nodefault.conf
+++ b/app/files/static/vhost_nodefault.conf
@@ -42,7 +42,8 @@ server {
     location ~ /\.                          { access_log off; log_not_found off; deny all; }
     location ~ ~$                           { access_log off; log_not_found off; deny all; }
 
-    location ~* ^.+\.(jpg|jpeg|gif|png|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|js|flv|swf|svg|woff|woff2|eot)$ {
+    location / {
+        try_files $uri =404;
         expires max;
         access_log off;
         log_not_found off;

--- a/app/files/static/vhost_nodefault_fastcgi_1_backend.conf
+++ b/app/files/static/vhost_nodefault_fastcgi_1_backend.conf
@@ -34,14 +34,14 @@ server {
     location ~ /\.                          { access_log off; log_not_found off; deny all; }
     location ~ ~$                           { access_log off; log_not_found off; deny all; }
 
-    location ~* ^.+\.(jpg|jpeg|gif|png|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|js|flv|swf|svg|woff|woff2|eot)$ {
-        try_files $uri $uri/;
+    location / {
+        try_files $uri @php;
         expires max;
         access_log off;
         log_not_found off;
     }
 
-    location / {
+    location @php {
         include fastcgi_params;
         fastcgi_intercept_errors on;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;

--- a/app/files/static/vhost_nodefault_no_http_fastcgi_1_backend.conf
+++ b/app/files/static/vhost_nodefault_no_http_fastcgi_1_backend.conf
@@ -26,14 +26,14 @@ server {
     location ~ /\.                          { access_log off; log_not_found off; deny all; }
     location ~ ~$                           { access_log off; log_not_found off; deny all; }
 
-    location ~* ^.+\.(jpg|jpeg|gif|png|ico|css|zip|tgz|gz|rar|bz2|pdf|txt|tar|wav|bmp|rtf|js|flv|swf|svg|woff|woff2|eot)$ {
-        try_files $uri $uri/;
+    location / {
+        try_files $uri @php;
         expires max;
         access_log off;
         log_not_found off;
     }
 
-    location / {
+    location @php {
         include fastcgi_params;
         fastcgi_intercept_errors on;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;


### PR DESCRIPTION
Смысл фикса в том, что мы хотим чтобы все запросы, которые
не могут быть обработаны как файл - так или иначе передавались в php.

С явным перечислением типов файлов (css|flv|js...) необходимо вносить
расширение файла на каждый тип файла который мы хотим отдавать
статически.

Вместо этого гораздо удобнее сразу пробовать отдать запрошенный урл как
файл, и если файла нет - отправить запрос на обработку в php.