### PR TITLE
Update app.php-fpm state

### DIFF
--- a/app/files/php-generic/pool.conf
+++ b/app/files/php-generic/pool.conf
@@ -7,7 +7,7 @@ listen.owner = www-data
 listen.group = www-data
 listen.mode = 0660
 
-php_admin_value[error_log] = /var/log/php/{{ php_version }}-fpm/{{ app_name }}.error.log
+php_admin_value[error_log] = {{ error_log }}
 php_admin_flag[log_errors] = on
 
 {{ config }}

--- a/app/files/php-generic/pool.conf
+++ b/app/files/php-generic/pool.conf
@@ -7,9 +7,7 @@ listen.owner = www-data
 listen.group = www-data
 listen.mode = 0660
 
-{{ pm }}
-
 php_admin_value[error_log] = /var/log/php/{{ php_version }}-fpm/{{ app_name }}.error.log
 php_admin_flag[log_errors] = on
 
-{{ php_admin }}
+{{ config }}

--- a/app/php-fpm.sls
+++ b/app/php-fpm.sls
@@ -16,23 +16,6 @@
 
       {%- include "app/_user_and_source.sls" with context %}
 
-app_php-fpm_app_pool_config_{{ loop.index }}:
-  file.managed:
-    - name: /etc/php/{{ app["pool"]["php_version"] }}/fpm/pool.d/{{ app_name }}.conf
-      {%- if "pool_contents" in app["pool"] %}
-    - contents: {{ app["pool"]["pool_contents"] | replace("__APP_NAME__", app_name) | yaml_encode }}
-      {%- else %}
-    - source: {{ app["pool"]["pool_template"] }}
-    - template: jinja
-    - defaults:
-        app_name: {{ app_name }}
-        user: {{ _app_user }}
-        group: {{ _app_group }}
-        php_version: {{ app["pool"]["php_version"] }}
-        config: {{ app["pool"]["config"] | yaml_encode }}
-      {%- endif %}
-
-
       {%- set default_pool_log_file = "/var/log/php/" ~ app["pool"]["php_version"] ~ "-fpm/" ~ app_name ~ ".error.log" %}
       {%- if "log" in app["pool"] %}
         {%- set _pool_log_file = app["pool"]["log"]["file"]|replace("__APP_NAME__", app_name)|default(default_pool_log_file) %}
@@ -54,6 +37,23 @@ app_php-fpm_app_pool_config_{{ loop.index }}:
         {%- set _pool_log_log_mode = "644" %}
         {%- set _pool_log_rotate_count = "31" %}
         {%- set _pool_log_rotate_when = "daily" %}
+      {%- endif %}
+
+app_php-fpm_app_pool_config_{{ loop.index }}:
+  file.managed:
+    - name: /etc/php/{{ app["pool"]["php_version"] }}/fpm/pool.d/{{ app_name }}.conf
+      {%- if "pool_contents" in app["pool"] %}
+    - contents: {{ app["pool"]["pool_contents"] | replace("__APP_NAME__", app_name) | yaml_encode }}
+      {%- else %}
+    - source: {{ app["pool"]["pool_template"] }}
+    - template: jinja
+    - defaults:
+        app_name: {{ app_name }}
+        user: {{ _app_user }}
+        group: {{ _app_group }}
+        php_version: {{ app["pool"]["php_version"] }}
+        error_log: {{ _pool_log_file }}
+        config: {{ app["pool"]["config"] | yaml_encode }}
       {%- endif %}
 
 app_php-fpm_app_log_dir_{{ loop.index }}:

--- a/app/php-fpm.sls
+++ b/app/php-fpm.sls
@@ -22,7 +22,7 @@ app_php-fpm_app_pool_config_{{ loop.index }}:
       {%- if "pool_contents" in app["pool"] %}
     - contents: {{ app["pool"]["pool_contents"] | replace("__APP_NAME__", app_name) | yaml_encode }}
       {%- else %}
-    - source: {{ app["pool"]["pool_config"] }}
+    - source: {{ app["pool"]["pool_template"] }}
     - template: jinja
     - defaults:
         app_name: {{ app_name }}

--- a/app/php-fpm.sls
+++ b/app/php-fpm.sls
@@ -38,8 +38,10 @@ app_php-fpm_app_pool_config_{{ loop.index }}:
 
       {%- endif %}
 
+
+      {%- set default_pool_log_file = "/var/log/php/" ~ app["pool"]["php_version"] ~ "-fpm/" ~ app_name ~ ".error.log" %}
       {%- if "log" in app["pool"] %}
-        {%- set _pool_log_dir = app["pool"]["log"]["dir"]|replace("__APP_NAME__", app_name)|default("/var/log/php") %}
+        {%- set _pool_log_file = app["pool"]["log"]["file"]|replace("__APP_NAME__", app_name)|default(default_pool_log_file) %}
         {%- set _pool_log_dir_user = app["pool"]["log"]["dir_user"]|default(_app_user) %}
         {%- set _pool_log_dir_group = app["pool"]["log"]["dir_group"]|default(_app_group) %}
         {%- set _pool_log_dir_mode = app["pool"]["log"]["dir_mode"]|default("755") %}
@@ -49,7 +51,7 @@ app_php-fpm_app_pool_config_{{ loop.index }}:
         {%- set _pool_log_rotate_count = app["pool"]["log"]["rotate_count"]|default("31") %}
         {%- set _pool_log_rotate_when = app["pool"]["log"]["rotate_when"]|default("daily") %}
       {%- else %}
-        {%- set _pool_log_dir = "/var/log/php" %}
+        {%- set _pool_log_file = default_pool_log_file %}
         {%- set _pool_log_dir_user = _app_user %}
         {%- set _pool_log_dir_group = _app_group %}
         {%- set _pool_log_dir_mode = "755" %}
@@ -62,7 +64,8 @@ app_php-fpm_app_pool_config_{{ loop.index }}:
 
 app_php-fpm_app_log_dir_{{ loop.index }}:
   file.directory:
-    - name: {{ _pool_log_dir }}/{{ app["pool"]["php_version"] }}-fpm
+    {%- set _pool_log_dir = _pool_log_file | regex_replace('/[^/]*$', '') %}
+    - name: {{ _pool_log_dir }}
     - user: {{ _pool_log_dir_user }}
     - group: {{ _pool_log_dir_group }}
     - mode: {{ _pool_log_dir_mode }}
@@ -70,16 +73,17 @@ app_php-fpm_app_log_dir_{{ loop.index }}:
 
 app_php-fpm_app_log_file_{{ loop.index }}:
   file.managed:
-    - name: {{ _pool_log_dir }}/{{ app["pool"]["php_version"] }}-fpm/{{ app_name }}.error.log
+    - name: {{ _pool_log_file }}
     - user: {{ _pool_log_log_user }}
     - group: {{ _pool_log_log_group }}
     - mode: {{ _pool_log_log_mode }}
+    - dir_mode: {{ _pool_log_dir_mode }}
 
 app_php-fpm_app_logrotate_file_{{ loop.index }}:
   file.managed:
     - name: /etc/logrotate.d/php{{ app["pool"]["php_version"] }}-fpm-{{ app_name }}
     - contents: |
-        {{ _pool_log_dir }}/{{ app["pool"]["php_version"] }}-fpm/{{ app_name }}.*.log {
+        {{ _pool_log_file }} {
           rotate {{ _pool_log_rotate_count }}
           {{ _pool_log_rotate_when }}
           missingok

--- a/app/php-fpm.sls
+++ b/app/php-fpm.sls
@@ -18,7 +18,7 @@
 
       {%- set default_pool_log_file = "/var/log/php/" ~ app["pool"]["php_version"] ~ "-fpm/" ~ app_name ~ ".error.log" %}
       {%- if "log" in app["pool"] %}
-        {%- set _pool_log_file = app["pool"]["log"]["file"]|replace("__APP_NAME__", app_name)|default(default_pool_log_file) %}
+        {%- set _pool_log_file = app["pool"]["log"]["error_log"]|replace("__APP_NAME__", app_name)|default(default_pool_log_file) %}
         {%- set _pool_log_dir_user = app["pool"]["log"]["dir_user"]|default(_app_user) %}
         {%- set _pool_log_dir_group = app["pool"]["log"]["dir_group"]|default(_app_group) %}
         {%- set _pool_log_dir_mode = app["pool"]["log"]["dir_mode"]|default("755") %}

--- a/app/php-fpm.sls
+++ b/app/php-fpm.sls
@@ -56,6 +56,7 @@ app_php-fpm_app_pool_config_{{ loop.index }}:
         config: {{ app["pool"]["config"] | yaml_encode }}
       {%- endif %}
 
+  {%- if not _pool_log_file.startswith("/var/log") %}
 app_php-fpm_app_log_dir_{{ loop.index }}:
   file.directory:
     {%- set _pool_log_dir = _pool_log_file | regex_replace('/[^/]*$', '') %}
@@ -64,6 +65,7 @@ app_php-fpm_app_log_dir_{{ loop.index }}:
     - group: {{ _pool_log_dir_group }}
     - mode: {{ _pool_log_dir_mode }}
     - makedirs: True
+  {%- endif %}
 
 app_php-fpm_app_log_file_{{ loop.index }}:
   file.managed:

--- a/app/php-fpm.sls
+++ b/app/php-fpm.sls
@@ -29,13 +29,7 @@ app_php-fpm_app_pool_config_{{ loop.index }}:
         user: {{ _app_user }}
         group: {{ _app_group }}
         php_version: {{ app["pool"]["php_version"] }}
-        pm: {{ app["pool"]["pm"] | yaml_encode }}
-        {%- if "php_admin" in app["pool"] %}
-        php_admin: {{ app["pool"]["php_admin"] | yaml_encode }}
-        {%- else %}
-        php_admin: "; no other admin vals"
-        {%- endif %}
-
+        config: {{ app["pool"]["config"] | yaml_encode }}
       {%- endif %}
 
 

--- a/app/php-fpm.sls
+++ b/app/php-fpm.sls
@@ -45,7 +45,7 @@ app_php-fpm_app_pool_config_{{ loop.index }}:
       {%- if "pool_contents" in app["pool"] %}
     - contents: {{ app["pool"]["pool_contents"] | replace("__APP_NAME__", app_name) | yaml_encode }}
       {%- else %}
-    - source: {{ app["pool"]["pool_template"] }}
+    - source: {{ app["pool"].get("pool_template", "salt://app/files/php-generic/pool.conf") }}
     - template: jinja
     - defaults:
         app_name: {{ app_name }}

--- a/app/pillar.example
+++ b/app/pillar.example
@@ -23,7 +23,7 @@ app:
           pool_template: salt://app/files/.../pool.conf
           reload: False # Usually restarting php-fpm on each app is not recommended, but it is ok for one app server setup flow
           log: # optional pool log params
-            file: /var/www/__APP_NAME__/log/php/__APP_NAME__.error.log # by default pool logs are in /var/log/php
+            error_log: /var/www/__APP_NAME__/log/php/__APP_NAME__.error.log # by default pool logs are in /var/log/php
             dir_user: someapp
             dir_group: someapp
             dir_mode: 755
@@ -43,7 +43,7 @@ app:
             php_admin_flag[html_errors] = off
             php_admin_value[post_max_size] = 25M
             php_admin_value[upload_max_filesize] = 25M
-          #pool_contents: | # optional, instead of pool_template+pm+php_admin you can set this pillar for the complete contents
+          #pool_contents: | # optional, instead of pool_template+config you can set this pillar for the complete contents
           #  [__APP_NAME__]
           #  user = __APP_NAME__
           #  group = __APP_NAME__

--- a/app/pillar.example
+++ b/app/pillar.example
@@ -33,13 +33,13 @@ app:
             rotate_count: 31
             rotate_when: weekly
           php_version: 7.4
-          pm: |
+          config: |
             pm = dynamic
             pm.max_children = 50
             pm.start_servers = 20
             pm.min_spare_servers = 10
             pm.max_spare_servers = 40
-          php_admin: |
+
             php_admin_flag[html_errors] = off
             php_admin_value[post_max_size] = 25M
             php_admin_value[upload_max_filesize] = 25M

--- a/app/pillar.example
+++ b/app/pillar.example
@@ -20,7 +20,7 @@ app:
           target: /opt/__APP_NAME__/venv
         # only for php-fpm
         pool:
-          pool_template: salt://app/files/.../pool.conf
+          #pool_template: salt://app/files/.../pool.conf # optional, by default uses salt://app/files/php-generic/pool.conf
           reload: False # Usually restarting php-fpm on each app is not recommended, but it is ok for one app server setup flow
           log: # optional pool log params
             error_log: /var/www/__APP_NAME__/log/php/__APP_NAME__.error.log # by default pool logs are in /var/log/php

--- a/app/pillar.example
+++ b/app/pillar.example
@@ -20,7 +20,7 @@ app:
           target: /opt/__APP_NAME__/venv
         # only for php-fpm
         pool:
-          pool_config: salt://app/files/.../pool.conf
+          pool_template: salt://app/files/.../pool.conf
           reload: False # Usually restarting php-fpm on each app is not recommended, but it is ok for one app server setup flow
           log: # optional pool log params
             file: /var/www/__APP_NAME__/log/php/__APP_NAME__.error.log # by default pool logs are in /var/log/php
@@ -43,7 +43,7 @@ app:
             php_admin_flag[html_errors] = off
             php_admin_value[post_max_size] = 25M
             php_admin_value[upload_max_filesize] = 25M
-          #pool_contents: | # optional, instead of pool_config+pm+php_admin you can set this pillar for the complete contents
+          #pool_contents: | # optional, instead of pool_template+pm+php_admin you can set this pillar for the complete contents
           #  [__APP_NAME__]
           #  user = __APP_NAME__
           #  group = __APP_NAME__

--- a/app/pillar.example
+++ b/app/pillar.example
@@ -23,7 +23,7 @@ app:
           pool_config: salt://app/files/.../pool.conf
           reload: False # Usually restarting php-fpm on each app is not recommended, but it is ok for one app server setup flow
           log: # optional pool log params
-            dir: /var/www/__APP_NAME__/log/php # by default pool logs are in /var/log/php
+            file: /var/www/__APP_NAME__/log/php/__APP_NAME__.error.log # by default pool logs are in /var/log/php
             dir_user: someapp
             dir_group: someapp
             dir_mode: 755

--- a/app/pillar.wordpress.example
+++ b/app/pillar.wordpress.example
@@ -45,7 +45,7 @@ app:
             set -e
             curl -sS https://wordpress.org/latest.tar.gz | tar zxf -
         pool:
-          pool_config: salt://app/files/wp/pool.conf
+          pool_template: salt://app/files/wp/pool.conf
           php_version: 7.4
           reload: True
           pm: |


### PR DESCRIPTION
Зміни:
1) змінено `pool["pool_config"]` на `pool["pool_template"]`, ключ став опціональним. 
По дефолту використовується [pool.conf](https://github.com/sysadmws/sysadmws-formula/blob/master/app/files/php-generic/pool.conf)
2) змінено `pool["log"]["dir"]` на `pool["log"]["error_log"]`
3) видалено `pool["pm"]` та `pool["php_admin"]`, замість них додано `pool["config"]`
4) не змінюється овнер діректорії з логами php, якщо шлях починається з `/var/log`

---
1 - суть ключа та ж сама, змінилась назва, щоб не повторюватись з [3]
2 - змінився підхід до управління логами: задавати треба лог файл, chmod/chown на діректорію з логами задається як і раніше. Тут же додалась змінна до конфігу pool.conf - `{{ error_log }}` яка як і в nginx веде до лог файлу. Керувати логом можна лише з піллару.
3 - дві секції зайві в нашому випадку, бо вони вставляються в 1 файл, і нічим крім назви не відрізняються