### PR TITLE
app.php-fpm: correct log managing

### DIFF
--- a/app/php-fpm.sls
+++ b/app/php-fpm.sls
@@ -16,7 +16,7 @@
 
       {%- include "app/_user_and_source.sls" with context %}
 
-      {%- set default_pool_log_file = "/var/log/php/" ~ app["pool"]["php_version"] ~ "-fpm/" ~ app_name ~ ".error.log" %}
+      {%- set default_pool_log_file = "/var/log/php/" ~ app_name ~ "/php" ~ app["pool"]["php_version"] ~ "-fpm-" ~ app_name ~ ".error.log" %}
       {%- if "log" in app["pool"] %}
         {%- set _pool_log_file = app["pool"]["log"]["error_log"]|replace("__APP_NAME__", app_name)|default(default_pool_log_file) %}
         {%- set _pool_log_dir_user = app["pool"]["log"]["dir_user"]|default(_app_user) %}
@@ -56,16 +56,13 @@ app_php-fpm_app_pool_config_{{ loop.index }}:
         config: {{ app["pool"]["config"] | yaml_encode }}
       {%- endif %}
 
-  {%- if not _pool_log_file.startswith("/var/log") %}
 app_php-fpm_app_log_dir_{{ loop.index }}:
   file.directory:
-    {%- set _pool_log_dir = _pool_log_file | regex_replace('/[^/]*$', '') %}
-    - name: {{ _pool_log_dir }}
+    - name: {{ _pool_log_file | regex_replace('/[^/]*$', '') }}
     - user: {{ _pool_log_dir_user }}
     - group: {{ _pool_log_dir_group }}
     - mode: {{ _pool_log_dir_mode }}
     - makedirs: True
-  {%- endif %}
 
 app_php-fpm_app_log_file_{{ loop.index }}:
   file.managed:

--- a/php-fpm/init.sls
+++ b/php-fpm/init.sls
@@ -12,6 +12,14 @@ php-fpm_repo_deb:
     - keyid: E5267A6C
     - refresh: True
 
+php-fpm_app_log_dir:
+  file.directory:
+    - name: /var/log/php
+    - makedirs: True
+    - user: root
+    - group: root
+    - mode: 755
+
   {%- for version, params in php_fpm["versions"].items() %}
 php-fpm_installed_{{ loop.index }}:
   pkg.installed:


### PR DESCRIPTION
Continues the ea4026c406249ff7785f97df7d2268bcdeccfd79
  Since each php-fpm pool runs with different user
we need separate dir for each applications
so each php-fpm pool coud create logs file in it on its own.