### PR TITLE
sentry: fix vroom path in backup_volumes.sh

### DIFF
--- a/sentry/files/backup_volumes.sh
+++ b/sentry/files/backup_volumes.sh
@@ -16,7 +16,7 @@ mkdir -p /opt/sentry/backup/volumes/
     docker run --rm --volumes-from sentry-self-hosted-zookeeper-1	-v /opt/sentry/backup/volumes/:/backup ubuntu tar cf /backup/sentry-self-hosted-zookeeper-1.tar	/var/lib/zookeeper/data  /var/lib/zookeeper/log
   fi
   if docker ps -a --format '{{.Names}}' | grep -q 'sentry-self-hosted-vroom-1'; then
-    docker run --rm --volumes-from sentry-self-hosted-vroom-1		-v /opt/sentry/backup/volumes/:/backup ubuntu tar cf /backup/sentry-self-hosted-vroom-1.tar		/var/lib/sentry-profiles
+    docker run --rm --volumes-from sentry-self-hosted-vroom-1		-v /opt/sentry/backup/volumes/:/backup ubuntu tar cf /backup/sentry-self-hosted-vroom-1.tar		/var/vroom/sentry-profiles
   fi
   ##
 [[ -f /opt/sentry/.env.custom ]] && docker-compose --file /opt/sentry/docker-compose.yml --env-file /opt/sentry/.env.custom up -d || docker-compose --file /opt/sentry/docker-compose.yml up -d


### PR DESCRIPTION
Upstream Sentry self-hosted moved the vroom profiles volume mount
from /var/lib/sentry-profiles to /var/vroom/sentry-profiles, which
caused tar to fail with "Cannot stat: No such file or directory"
and aborted the whole backup run.

Update the vroom tar target to /var/vroom/sentry-profiles to match
the current container layout. restore_volumes.sh is unaffected
since it extracts archives by relative paths.