### PR TITLE
fix(atlantis): use versioned dir + symlink, restart on changes

### DIFF
--- a/atlantis/atlantis.sls
+++ b/atlantis/atlantis.sls
@@ -32,14 +32,35 @@ atlantis_config_repos:
     - contents: |
         {{ pillar['atlantis']['repos'] | indent(8) }}
 
-atlantis_binary:
-  archive.extracted:
-    - name: /opt/atlantis/bin
-    - source: https://github.com/runatlantis/atlantis/releases/download/v{{ pillar['atlantis']['version'] }}/atlantis_linux_amd64.zip
+atlantis_install_dir:
+  file.directory:
+    - name: /opt/atlantis/versions/{{ pillar['atlantis']['version'] }}
     - user: 0
     - group: 0
+    - mode: '0755'
+    - makedirs: True
+
+atlantis_binary:
+  archive.extracted:
+    - name: /opt/atlantis/versions/{{ pillar['atlantis']['version'] }}
+    - source: https://github.com/runatlantis/atlantis/releases/download/v{{ pillar['atlantis']['version'] }}/atlantis_linux_amd64.zip
+    - source_hash: https://github.com/runatlantis/atlantis/releases/download/v{{ pillar['atlantis']['version'] }}/checksums.txt
+    - user: root
+    - group: root
     - enforce_toplevel: False
-    - skip_verify: True
+    - if_missing: /opt/atlantis/versions/{{ pillar['atlantis']['version'] }}/atlantis
+    - require:
+      - file: atlantis_install_dir
+
+atlantis_symlink:
+  file.symlink:
+    - name: /opt/atlantis/bin/atlantis
+    - target: /opt/atlantis/versions/{{ pillar['atlantis']['version'] }}/atlantis
+    - force: True
+    - require:
+      - archive: atlantis_binary
+    - watch_in:
+      - service: atlantis
 
 atlantis_systemd_1:
   file.managed:
@@ -61,7 +82,7 @@ systemd-reload:
   cmd.run:
     - name: systemctl daemon-reload
     - onchanges:
-      - file: /etc/systemd/system/atlantis.service
+      - file: atlantis_systemd_1
 
 atlantis_systemd_2:
   service.running:
@@ -72,8 +93,11 @@ atlantis_systemd_3:
   cmd.run:
     - name: systemctl restart atlantis
     - onchanges:
-      - file: /etc/systemd/system/atlantis.service
-      - file: /opt/atlantis/etc/config.yaml
-      - file: /opt/atlantis/etc/repos.yaml
+      - file: atlantis_systemd_1
+      - file: atlantis_config
+      - file: atlantis_config_repos
+      - file: atlantis_symlink
+    - require:
+      - cmd: systemd-reload
 {% endif %}
 


### PR DESCRIPTION
## What

Refactor Atlantis SaltStack formula to properly handle version upgrades.

## Why

`archive.extracted` checks for existence of files in the target directory,
not the source URL. Bumping `pillar['atlantis']['version']` did not trigger
a re-download — the old binary stayed in place. This blocked the upgrade
from v0.28.5 to v0.42.0 (needed to fix expired HashiCorp GPG key 72D7468F).

`skip_verify: True` also disabled checksum verification, leaving no way
for Salt to detect a stale archive.

## Changes

- Install into versioned directory: `/opt/atlantis/versions/<version>/`
- Symlink `/opt/atlantis/bin/atlantis` → versioned binary
- `if_missing` checks for the versioned binary path, not the bin dir
- `source_hash` via official `checksums.txt` from the release (replaces `skip_verify`)
- systemd unit restarts on symlink or config changes via `service.running` + `watch`
- `daemon-reload` runs `onchanges` for the unit file