### PR TITLE
feat(sentry): add compose_override pillar for docker-compose tweaks

### DIFF
--- a/sentry/init.sls
+++ b/sentry/init.sls
@@ -112,6 +112,18 @@ sentry_geoip_conf:
     - mode: 0644
     - contents: {{ pillar["sentry"]["geoip_conf"] | yaml_encode }}
 
+  {%- if "compose_override" in pillar["sentry"] %}
+sentry_compose_override:
+  file.managed:
+    - name: /opt/sentry/docker-compose.override.yml
+    - mode: 0644
+    - contents: {{ pillar["sentry"]["compose_override"] | yaml_encode }}
+  {%- else %}
+sentry_compose_override_absent:
+  file.absent:
+    - name: /opt/sentry/docker-compose.override.yml
+  {%- endif %}
+
 sentry_create_env_custom:
   file.copy:
     - name: /opt/sentry/.env.custom

--- a/sentry/pillar.example
+++ b/sentry/pillar.example
@@ -28,6 +28,18 @@ sentry:
     AccountID 012345
     LicenseKey foobarbazbuz
     EditionIDs GeoLite2-City
+  # Optional: docker-compose.override.yml content for tweaking upstream services
+  # (memory limits, extra env vars, etc.). Written as-is to
+  # /opt/sentry/docker-compose.override.yml and auto-merged by docker-compose.
+  # See: https://docs.docker.com/compose/multiple-compose-files/merge/
+  # compose_override: |
+  #   services:
+  #     clickhouse:
+  #       environment:
+  #         MAX_MEMORY_USAGE_RATIO: "0.2" # limit clickhouse RAM to 20% of host
+  #     kafka:
+  #       environment:
+  #         KAFKA_HEAP_OPTS: '-Xmx512m -Xms512m'
   config:
     # compose_profiles: errors-only # optional for versions 24.8.0+
     single_organization: True


### PR DESCRIPTION
Render /opt/sentry/docker-compose.override.yml from sentry:compose_override pillar. Auto-merged by docker-compose, so users can cap RAM (e.g. clickhouse  MAX_MEMORY_USAGE_RATIO, kafka KAFKA_HEAP_OPTS) or add env vars without  patching upstream self-hosted repo (which is force-reset by git.latest).
