### PR TITLE
Enhance RabbitMQ plugin installation and feature flag options

### DIFF
--- a/rabbitmq/install.sls
+++ b/rabbitmq/install.sls
@@ -43,7 +43,18 @@ rabbitmq_repo:
         ##
         deb [arch=amd64 signed-by=/usr/share/keyrings/com.rabbitmq.team.gpg] https://deb1.rabbitmq.com/rabbitmq-server/{{ grains["os"].lower() }}/{{ grains["oscodename"] }} {{ grains["oscodename"] }} main
         deb [arch=amd64 signed-by=/usr/share/keyrings/com.rabbitmq.team.gpg] https://deb2.rabbitmq.com/rabbitmq-server/{{ grains["os"].lower() }}/{{ grains["oscodename"] }} {{ grains["oscodename"] }} main
- 
+
+  {#- Optional: enable all feature flags on the currently-installed broker before any
+      upgrade. Required before upgrading to a major RabbitMQ version that drops support
+      for older feature-flag states. Safe no-op on fresh installs (onlyif skips when the
+      broker is not yet up). #}
+  {%- if pillar["rabbitmq"].get("enable_all_feature_flag", False) %}
+rabbit_enable_feature_flag:
+  cmd.run:
+    - name: rabbitmqctl enable_feature_flag all
+    - onlyif: rabbitmqctl status 2>/dev/null | grep -q Uptime
+  {%- endif %}
+
 rabbit_pkg:
   {%- if "version" in pillar["rabbitmq"] %}
     {%- if pillar["rabbitmq"]["version"] == "latest" %}
@@ -116,6 +127,45 @@ rabbit_service_4:
   cmd.run:
     - name: systemctl daemon-reload
 
+  {#- Download community plugin .ez files BEFORE the broker restart, so all .ez referenced
+      by /etc/rabbitmq/enabled_plugins are on disk when the broker starts. Otherwise
+      rabbitmq-plugins enable for any other plugin fails with plugins_not_found for the
+      community ones that are already recorded as enabled. #}
+  {%- for plugin in pillar["rabbitmq"].get("plugins", []) %}
+    {%- if plugin is mapping %}
+rabbit_plugin_{{ loop.index }}_download:
+  cmd.run:
+    - name: |
+        set -eo pipefail
+        RMQVER=$(dpkg-query -W -f='${Version}' rabbitmq-server | sed -E 's/^[0-9]+://;s/[-+~].*//')
+        DEST_DIR="/usr/lib/rabbitmq/lib/rabbitmq_server-${RMQVER}/plugins"
+        DEST_FILE="${DEST_DIR}/$(basename '{{ plugin["url"] }}')"
+        # remove stale copies of this plugin from both the active versioned dir and the
+        # system-wide /usr/lib/rabbitmq/plugins dir. -type f leaves bundled-plugin dirs
+        # like amqp10_client-3.13.6/ untouched. ! -path "$DEST_FILE" preserves our target
+        # if it is already at the requested version.
+        # Default pattern is the safe `<name>-<digit>*` (versioned files only). Set
+        # `force_cleanup: True` on the pillar entry to widen it to `<name>-*` so any file
+        # with the plugin name prefix is removed (e.g. `<name>.bak`, `<name>-foo`).
+        for D in "$DEST_DIR" "/usr/lib/rabbitmq/plugins"; do
+          [ -d "$D" ] || continue
+      {%- if plugin.get("force_cleanup", False) %}
+          find "$D" -maxdepth 1 -type f -name '{{ plugin["name"] }}-*' ! -path "$DEST_FILE" -print -delete
+      {%- else %}
+          find "$D" -maxdepth 1 -type f -name '{{ plugin["name"] }}-[0-9]*' ! -path "$DEST_FILE" -print -delete
+      {%- endif %}
+        done
+        if [ ! -f "$DEST_FILE" ]; then
+          curl -fsSL -o "${DEST_FILE}.tmp" '{{ plugin["url"] }}'
+          mv "${DEST_FILE}.tmp" "$DEST_FILE"
+          chmod 644 "$DEST_FILE"
+          echo "downloaded $(basename '{{ plugin["url"] }}')"
+        fi
+    - require:
+      - pkg: rabbit_pkg
+    {%- endif %}
+  {%- endfor %}
+
 rabbit_service_5:
   cmd.run:
     - name: service rabbitmq-server restart
@@ -138,9 +188,17 @@ rabbit_fix_salt_module:
         timeout 2m bash -c 'salt-call saltutil.refresh_modules'; } || true
 
   {%- for plugin in pillar["rabbitmq"].get("plugins", []) %}
+    {%- if plugin is mapping %}
+rabbit_plugin_{{ loop.index }}:
+  rabbitmq_plugin.enabled:
+    - name: '{{ plugin["name"] }}'
+    - require:
+      - cmd: rabbit_plugin_{{ loop.index }}_download
+    {%- else %}
 rabbit_plugin_{{ loop.index }}:
   rabbitmq_plugin.enabled:
     - name: {{ plugin }}
+    {%- endif %}
   {%- endfor %}
 
 {% endif %}

--- a/rabbitmq/pillar.example
+++ b/rabbitmq/pillar.example
@@ -3,6 +3,7 @@
 rabbitmq:
   version: 4.2.3 # optional, specific version or latest, if omitted, install latest first, then keep it without upgrades
   #local_ip: 1.2.3.4 # optional, make sure /etc/hosts has short hostname resolution to this local IP, otherwise rabbitmq will not start, if omitted, 127.0.1.1 is used
+  #enable_all_feature_flag: True # optional, runs `rabbitmqctl enable_feature_flag all` BEFORE the package upgrade on the currently-installed broker; required before upgrading across major versions that drop older feature-flag states. Skipped silently on fresh installs.
   config: # optional
     - 'key = val' # see https://github.com/rabbitmq/rabbitmq-server/blob/v3.7.x/docs/rabbitmq.conf.example, each item is copied as is
   admin:
@@ -14,6 +15,17 @@ rabbitmq:
   acme_account: example.com # acme state account
   plugins: # optional
     - rabbitmq_management
+    # community plugin, downloaded as .ez and enabled. Pick a URL whose plugin version
+    # matches RabbitMQ major.minor (RabbitMQ 4.2.x -> plugin 4.2.x). The on-disk filename
+    # is derived from the URL via basename. Removing the entry stops managing it; disable
+    # manually on the host if needed.
+    # Cleanup of stale copies runs in both /usr/lib/rabbitmq/lib/rabbitmq_server-<VER>/plugins
+    # and /usr/lib/rabbitmq/plugins. By default only files matching the safe pattern
+    # `<name>-<digit>*` are removed. Set force_cleanup: True to widen the pattern to
+    # `<name>-*` so files like `<name>.bak` or `<name>-foo` are also removed.
+    - name: rabbitmq_delayed_message_exchange
+      url: https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/v4.2.0/rabbitmq_delayed_message_exchange-4.2.0.ez
+      #force_cleanup: True   # optional, default False
   vhosts:
     - name: vhost_a
       present: True


### PR DESCRIPTION

- Extend `plugins:` pillar to accept dict entries `{name, url, force_cleanup?}`: downloads the .ez (filename derived from URL via basename) into the active /usr/lib/rabbitmq/lib/rabbitmq_server-<VER>/plugins/ dir BEFORE the broker restart, so /etc/rabbitmq/enabled_plugins references all stay resolvable on start-up. String entries (built-in plugins) keep their original behaviour.
- Cleanup of stale copies runs in both the active versioned dir and /usr/lib/rabbitmq/plugins/. Default pattern `<name>-<digit>*` keeps unrelated files (`<name>.bak`, `<name>-foo`) intact; per-plugin `force_cleanup: True` widens it to `<name>-*`.
- Add optional `rabbitmq:enable_all_feature_flag: True` which runs `rabbitmqctl enable_feature_flag all` BEFORE `rabbit_pkg`, gated by an `onlyif: rabbitmqctl status` so fresh installs skip it silently.