### PR TITLE
binsvc: unify expansion via two-pass loop; merge_globals takes kwargs

### DIFF
--- a/binsvc/WHITEPAPER.md
+++ b/binsvc/WHITEPAPER.md
@@ -101,7 +101,14 @@ binsvc:
       install_dir / user / ssh / svc / config / systemd / nginx: {...}
 ```
 
-`init.sls` first merges all instances, then resolves and dispatches each one:
+`init.sls` runs **two passes** over `binsvc:instances`. Pass 1 merges and
+formats *every* instance; pass 2 gathers cross-instance scrape jobs and
+dispatches the `selected` subset. The split exists because step 5's gather needs
+every producer already formatted — including producers excluded from this apply.
+Merge and format are purely per-instance, so they share one pass; only the
+gather is cross-instance, so it gets its own.
+
+**Pass 1 — for every instance:**
 
 1. **Load preset** (`load_preset`) — parse `presets/<name>.yaml` once per run
    (`_preset_cache`), deep-merged with any `binsvc:presets:<name>` pillar
@@ -109,9 +116,6 @@ binsvc:
 2. **Merge** — `settings = merge(defaults, preset, instance)`. Dicts merge
    recursively; everything else (incl. **lists**) is replaced wholesale by the
    more-specific layer. (`svc.args` is the one exception — §10.)
-   This pass runs for every instance before any instance is expanded or
-   dispatched, so a consumer can gather merged producer stanzas from the same
-   host without depending on declaration order.
 3. **Resolve version/source** (`resolve_latest_version` → `lib.py`'s
    `resolve_latest`, which does the HTTP via `requests.get`, cached on the render
    host — §10) — through the named `svc.version_resolver` (`github` by default).
@@ -120,10 +124,18 @@ binsvc:
    template. Grafana resolves both `latest` and concrete versions through its
    packages API, filling `svc.source` and `svc.source_hash` because the tarball
    URL contains a build ID that is not derivable from the version alone (§10).
-4. **Expand placeholders, two passes** (`expand`, §5).
+   **This is the one network step, and the only one `binsvc:filter` gates** — it
+   runs only for `selected` instances; unselected ones still format (so they can
+   be gathered) but keep their unresolved `version`/`tag`.
+4. **Expand placeholders, two passes** (`expand`, §5). Uniform: scrape stanzas
+   are expanded by this same pass, in the producer's own scope — there is no
+   separate scrape-formatting step.
+
+**Pass 2 — for every `selected` instance:**
+
 5. **Inject gathered scrape jobs** when `scrape_collect` is set. `vmagent` uses
-   this to append literal jobs from matching producers' `scrape` stanzas into
-   `config.promscrape.yml.contents.scrape_configs`, reusing the normal
+   this to append jobs from matching producers' (now-expanded) `scrape` stanzas
+   into `config.promscrape.yml.contents.scrape_configs`, reusing the normal
    `config_file` block.
 6. **Dispatch** building blocks in fixed order, threading "what changed" into
    systemd's restart trigger (§6).
@@ -272,17 +284,18 @@ production path — these presets are not replacements or a migration invitation
   remain owned by the acme formula.
 - **Two-phase expand, no phase 3.** See §5 — prefer computing a value inside the
   block that needs it over adding a global phase.
-- **`binsvc:filter` gates dispatch, never the merge.** An operator-typed
-  selector string (`"name: vm* *gra*; preset: exporter*"`, semicolon clauses,
-  union semantics, `fnmatch` globs) scopes a `state.apply` to a subset of
-  instances. It is intentionally a small **string DSL**, not structured pillar,
-  because it is typed by hand on the CLI where nested `{"":{"":[""]}}` is
-  error-prone; `parse_filter` hardens it (`split(":", 1)`, fail loud on unknown
-  key / empty globs). The pass-1 loop still merges **all** instances so
-  `collect_scrape_jobs` sees the full set — only the pass-2 `dispatch` call is
-  filtered (unselected instances also skip the resolve/expand network cost).
-  This is **manual scoping, not change detection**: filtering to a new exporter
-  won't refresh vmagent's scrape config until vmagent is also in scope.
+- **`binsvc:filter` gates resolution and dispatch, never merge/format.** An
+  operator-typed selector string (`"name: vm* *gra*; preset: exporter*"`,
+  semicolon clauses, union semantics, `fnmatch` globs) scopes a `state.apply` to
+  a subset of instances. It is intentionally a small **string DSL**, not
+  structured pillar, because it is typed by hand on the CLI where nested
+  `{"":{"":[""]}}` is error-prone; `parse_filter` hardens it (`split(":", 1)`,
+  fail loud on unknown key / empty globs). Pass 1 still merges **and formats**
+  every instance so `collect_scrape_jobs` sees them all expanded — the filter
+  gates only the `latest` resolution (the one network step) and the pass-2
+  `dispatch`. This is **manual scoping, not change detection**: filtering to a
+  new exporter won't refresh vmagent's scrape config until vmagent is also in
+  scope.
 - **`binsvc:globals` are scope, not settings.** Operator-defined placeholders
   (`{foo}`) shared by every instance live in the **expand scope**, never in the
   `defaults→preset→instance` merge — they are template variables, not per-instance
@@ -333,7 +346,19 @@ production path — these presets are not replacements or a migration invitation
   This Puppet-exported-resources-style non-locality is contained deliberately:
   producers use an explicit `scrape.vmagent` selector, jobs are literal
   operator-authored data, collection is host-local, and duplicate `job_name`
-  values fail the render instead of being renamed silently.
+  values fail the render instead of being renamed silently. A scrape job is
+  declared by the producer but rendered into the consumer's config, so it is
+  expanded **in the producer's scope, in pass 1** (before collection), not the
+  consumer's — by the *same* two-phase `expand` as every other config, with no
+  scrape-specific formatting step. That uniformity (no separate "kind" of
+  expansion to grow) is why the pipeline went to two passes (§4): the gather had
+  to move after formatting, which in turn freed scrape to be formatted normally.
+  The one wrinkle is the filter: since the `latest` resolution is gated to
+  selected instances, `version`/`tag` of a producer *not* in the selected subset
+  stay unresolved in its gathered jobs until a full apply — an accepted, narrow,
+  self-healing caveat; everything else (`name`/`grain_id`/`install_dir`/…)
+  resolves regardless. For values outside the placeholder set, use Salt jinja in
+  pillar.
 - **Program files root-owned; writable state via `svc.data_dirs`.** `fetch_archive`
   extracts as root (`--no-same-owner`), so program files are root-owned — a
   compromised service can't rewrite its own binary. Dirs the service must write

--- a/binsvc/init.sls
+++ b/binsvc/init.sls
@@ -92,7 +92,15 @@ def dispatch(prefix, settings):
     nginx_vhost(prefix, settings)
 
 
-# --- main loop: merge all, then expand/inject/dispatch per instance ----------
+# --- main loop: merge+format every instance, then gather+dispatch the selected -
+#
+# Two passes, because cross-instance scrape collection needs every producer
+# already formatted. Pass 1 (merge + expand) is purely per-instance and runs for
+# ALL instances, so a selected consumer can gather any producer's expanded
+# `scrape` jobs - including producers excluded from this apply. Pass 2 gathers
+# and dispatches only the `selected` subset. Expansion is uniform: scrape configs
+# are expanded by the same two-phase pass as everything else, in the producer's
+# own scope - no separate formatting step.
 
 instances = pillar("binsvc:instances", {})
 
@@ -106,7 +114,17 @@ global_vars = pillar("binsvc:globals", {})
 # overwritten in the second expand pass.
 PHASE2_PLACEHOLDERS = ("install_dir", "exec", "args", "user_name", "user_group")
 
-merged = {}
+# Optional `binsvc:filter` (operator-typed, usually on the CLI) scopes this apply
+# to a subset - e.g. pillar='{binsvc: {filter: "name: vm* *gra*"}}'. It gates the
+# expensive `latest` resolution (pass 1) and dispatch (pass 2); formatting itself
+# runs for every instance so cross-instance scrape gathering stays correct.
+selected = select_instances(instances, parse_filter(pillar("binsvc:filter", "")))
+if not selected and instances:
+    log.warning("binsvc:filter %r matched no instances; nothing to apply",
+                pillar("binsvc:filter", ""))
+
+# Pass 1: merge + two-phase expand every instance into a fully formatted dict.
+expanded = {}
 for instance_name, instance in instances.items():
     preset_name = instance.get("preset")
     preset = load_preset(preset_name) if preset_name else {}
@@ -123,43 +141,29 @@ for instance_name, instance in instances.items():
     if preset_args or instance_args:
         settings.setdefault("svc", {})["args"] = merge_args(preset_args, instance_args)
 
-    merged[instance_name] = settings
-
-# Optional `binsvc:filter` (operator-typed, usually on the CLI) scopes this apply
-# to a subset of instances - e.g. pillar='{binsvc: {filter: "name: vm* *gra*"}}'.
-# It gates dispatch ONLY: `merged` above stays complete so a selected vmagent
-# still gathers every exporter's scrape job, and unselected instances skip the
-# expensive resolve/expand below entirely.
-selected = select_instances(merged, parse_filter(pillar("binsvc:filter", "")))
-if not selected and merged:
-    log.warning("binsvc:filter %r matched no instances; nothing to apply",
-                pillar("binsvc:filter", ""))
-
-for instance_name, raw_settings in merged.items():
-    if instance_name not in selected:
-        continue
-
-    settings = merge(raw_settings)
-
     svc = settings.get("svc") or {}
-    if "source" in svc:
+    # Resolve `latest` only for selected instances - it's the one network step.
+    # Unselected producers still format (so consumers can gather their scrape
+    # jobs), but their {version}/{tag} stay at the unresolved value.
+    if "source" in svc and instance_name in selected:
         settings["svc"] = resolve_latest_version(svc)
         svc = settings["svc"]
 
     # Phase 1: resolve install_dir/source/exec against grain-derived identity
     # plus the instance's own static keys (name/type/version/tag/...).
     tag = svc.get("tag", svc.get("version", ""))
-    base_scope = merge_globals({
-        "name": instance_name,
-        "type": settings.get("type"),
-        "version": svc.get("version", ""),
-        "tag": tag,
-        "tag_vstrip": tag.lstrip("v"),
-        "osarch": normalize_osarch(grains("osarch") or ""),
-        "kernel_lower": (grains("kernel") or "").lower(),
-        "cpuarch": grains("cpuarch") or "",
-        "grain_id": grains("id") or "",
-    }, global_vars, extra_reserved=PHASE2_PLACEHOLDERS)
+    base_scope = merge_globals(global_vars,
+        extra_reserved=PHASE2_PLACEHOLDERS,
+        name=instance_name,
+        type=settings.get("type"),
+        version=svc.get("version", ""),
+        tag=tag,
+        tag_vstrip=tag.lstrip("v"),
+        osarch=normalize_osarch(grains("osarch") or ""),
+        kernel_lower=(grains("kernel") or "").lower(),
+        cpuarch=grains("cpuarch") or "",
+        grain_id=grains("id") or "",
+    )
     settings = expand(settings, base_scope)
 
     # Phase 2: a second pass for keys only resolvable once phase 1 has
@@ -175,8 +179,15 @@ for instance_name, raw_settings in merged.items():
                        user_group=user.get("group", user.get("name", "root")))
     settings = expand(settings, extra_scope)
 
+    expanded[instance_name] = settings
+
+# Pass 2: gather cross-instance scrape jobs and dispatch the selected instances.
+for instance_name, settings in expanded.items():
+    if instance_name not in selected:
+        continue
+
     if "scrape_collect" in settings:
-        jobs = collect_scrape_jobs(merged, instance_name)
+        jobs = collect_scrape_jobs(expanded, instance_name)
         append_at_path(settings, settings["scrape_collect"], jobs, unique_key="job_name")
 
     dispatch(["binsvc", instance_name], settings)

--- a/binsvc/lib.py
+++ b/binsvc/lib.py
@@ -77,14 +77,15 @@ def expand(mapping, scope=None, rounds=3):
     return result
 
 
-def merge_globals(reserved, global_vars, extra_reserved=()):
+def merge_globals(global_vars, *, extra_reserved=(), **reserved):
     """Overlay operator-supplied `binsvc:globals` onto the reserved expand scope.
 
-    Globals are literal substitution values shared by every instance (e.g.
-    `{foo}`). Raises ValueError if a global key shadows a reserved/derived
-    placeholder (`name`, `type`, `grain_id`, ...) - that is almost always a typo
-    that would otherwise silently break the identity placeholders. `extra_reserved`
-    names additional reserved placeholders injected *after* this call (the phase-2
+    The reserved/derived placeholders are passed directly as keyword arguments
+    (`name=..., grain_id=..., ...`); `global_vars` are the operator's literal
+    `{key}` values shared by every instance. Raises ValueError if a global key
+    shadows a reserved placeholder - that is almost always a typo that would
+    otherwise silently break the identity placeholders. `extra_reserved` names
+    additional reserved placeholders injected *after* this call (the phase-2
     scope keys), so colliding with them fails loud here instead of being silently
     overwritten in the second expand pass. Returns a new dict; inputs untouched."""
     clash = set(global_vars or {}) & (set(reserved) | set(extra_reserved))

--- a/binsvc/pillar.example
+++ b/binsvc/pillar.example
@@ -2,8 +2,10 @@
 # (VictoriaMetrics, VictoriaLogs, Grafana, Loki, Prometheus, exporters, ...)
 # under systemd, each independently configured.
 #
-# Resolution per instance, see binsvc/init.sls / readme.md for the full story:
-#   1. all instances are merged first:
+# Resolution, see binsvc/init.sls / readme.md for the full story. Pass 1 merges
+# and formats EVERY instance; pass 2 gathers cross-instance scrape jobs and
+# dispatches the selected subset:
+#   1. each instance is merged:
 #      settings = merge(binsvc/defaults.yaml, presets/<preset>.yaml, <instance>)
 #      - everything here merges deep-dict-wise / replaces-wholesale, EXCEPT
 #        structured svc.args, which is merged by flag name (merge_args in
@@ -11,13 +13,14 @@
 #        preset's args without restating storageDataPath/retentionPeriod/... too
 #        (string entries inside args lists are literal tokens; top-level raw
 #        string args replace wholesale)
-#   2. each instance resolves version/source, then every {placeholder} string
-#      anywhere in `settings` is expanded in two
+#   2. each instance resolves version/source (only if selected - see filter),
+#      then every {placeholder} string anywhere in `settings` is expanded in two
 #      passes - first against grain-derived identity + the instance's own
-#      static keys (name/type/version/tag/tag_vstrip/osarch/...), then again
-#      once install_dir/exec/args/user_name/user_group are themselves known.
-#   3. if `scrape_collect` is set, literal jobs from matching instances'
-#      `scrape` stanzas are appended to the configured config path.
+#      static keys (name/type/version/tag/tag_vstrip/osarch/grain_id/...), then
+#      again once install_dir/exec/args/user_name/user_group are themselves
+#      known. scrape stanzas are expanded by this same pass, in producer scope.
+#   3. if `scrape_collect` is set, the (now-expanded) jobs from matching
+#      instances' `scrape` stanzas are appended to the configured config path.
 #   4. building blocks run in order: user/ssh, config, svc (fetch), commands(pre),
 #      systemd, commands(post), nginx
 #
@@ -177,7 +180,16 @@ binsvc:
           # exporter_node preset sets args_prefix: "--".
           - web.listen-address: "127.0.0.1:9100"
       # Override the preset's vmagent: ["*"] default to narrow this producer to
-      # one local vmagent instance. Contributions are literal: no placeholders.
+      # one local vmagent instance.
+      #
+      # scrape.config is expanded like any other config, in the PRODUCER's own
+      # scope (a job is declared here yet rendered into the consumer's config),
+      # so {name}/{type}/{grain_id}/{install_dir}/... all work. One caveat: under
+      # binsvc:filter, {version}/{tag} of a producer NOT in the selected subset
+      # stay unresolved (resolution is gated to selected instances) until a full
+      # apply. For values outside the placeholder set, use Salt jinja IN PILLAR
+      # (rendered before binsvc; pillar only, not a bundled presets/*.yaml, which
+      # is yaml.safe_load'd) - e.g. {{ grains["fqdn"] }}.
       scrape:
         vmagent: ["metrics"]
         config:
@@ -185,6 +197,8 @@ binsvc:
             static_configs:
               - targets:
                   - "127.0.0.1:9100"
+                labels:
+                  instance: "{grain_id}"
 
     # --- Grafana from the official standalone tarball ---
     grafana:

--- a/binsvc/presets/exporter_node.yaml
+++ b/binsvc/presets/exporter_node.yaml
@@ -35,6 +35,8 @@ scrape:
     - job_name: node
       static_configs:
         - targets: ["127.0.0.1:9100"]
+          labels:
+            instance: "{grain_id}"
 
 systemd:
   Service:

--- a/binsvc/readme.md
+++ b/binsvc/readme.md
@@ -37,8 +37,6 @@ For every entry under `binsvc:instances`:
    literally, so value-less flags like `--livereload` can be mixed in. A
    top-level raw string `svc.args` is still a complete args line and replaces
    the previous layer wholesale.
-   `init.sls` does this for all instances first so consumers can gather merged
-   producer stanzas from the same host.
 2. **Resolve version/source**: `svc.version_resolver` selects resolver logic
    for the app. The default `github` resolver turns `version: latest` into a
    concrete GitHub release tag using `/releases/latest` (NOT `/tags` - the
@@ -48,7 +46,8 @@ For every entry under `binsvc:instances`:
    `/releases/latest` can point at an LTS branch. The `grafana` resolver uses
    Grafana's API to resolve both latest/concrete versions and the real package
    URL, because Grafana archive names contain build IDs that are not derivable
-   from the version alone.
+   from the version alone. This network step runs only for instances **selected**
+   by `binsvc:filter` (all of them when no filter is given).
 3. **Expand placeholders**, in two passes (`expand` in `lib.py`):
    - *Phase 1* against grain-derived identity (`osarch`, `kernel_lower`,
      `cpuarch`, `grain_id` = the minion id) plus the instance's own static keys
@@ -68,22 +67,39 @@ For every entry under `binsvc:instances`:
    An optional `binsvc:filter` (usually typed on the CLI, e.g.
    `pillar='{binsvc: {filter: "name: vm* *gra*; preset: exporter*"}}'`) scopes
    the apply to a subset: semicolon-separated `name`/`preset` glob clauses, union
-   semantics. It gates dispatch only - step 1 still merges every instance, so a
-   selected vmagent gathers all exporters' scrape jobs - while unselected
-   instances skip resolve/expand entirely. Manual scoping, not change detection:
-   a new exporter's job reaches vmagent only when vmagent is also in scope.
+   semantics. Steps 1 and 3 (merge + expand) still run for **every** instance so
+   a selected vmagent can gather any producer's scrape jobs; the filter gates
+   only the **resolution** (step 2) and **dispatch** (step 4). Manual scoping,
+   not change detection: a new exporter's job reaches vmagent only when vmagent
+   is also in scope.
    `fetch_archive` and `config_file` each return the list of pyobjects requisite
    references that mean "the binary/config changed"; `dispatch`
    threads that list into `systemd_unit`'s `watch`, so the service restarts
    exactly when it needs to - without any block hardcoding another block's
    state IDs.
 
-Before dispatch, an instance with `scrape_collect` gathers literal scrape jobs
-from all merged instances with a matching `scrape.vmagent` selector and appends
-them to the configured colon path, for example
-`config:promscrape.yml:contents:scrape_configs`. This is host-local by design:
-producers declare `scrape: {vmagent: <glob-or-list>, config: [...]}`, consumers
-opt in with `scrape_collect`, and duplicate `job_name` values fail the render.
+Resolution runs in two passes over `binsvc:instances`: **pass 1** merges and
+expands (steps 1-3) *every* instance into a fully formatted map; **pass 2**
+gathers cross-instance scrape jobs and dispatches (step 4) the selected subset.
+The split exists so a consumer can gather producers that were already formatted —
+including producers excluded from this apply.
+
+Before dispatch, an instance with `scrape_collect` gathers scrape jobs from all
+instances with a matching `scrape.vmagent` selector and appends them to the
+configured colon path, for example `config:promscrape.yml:contents:scrape_configs`.
+This is host-local by design: producers declare
+`scrape: {vmagent: <glob-or-list>, config: [...]}`, consumers opt in with
+`scrape_collect`, and duplicate `job_name` values fail the render.
+
+`scrape.config` is expanded by the **same two-phase pass as every other config**,
+in the **producer's** scope (a job is declared by the producer but rendered into
+the consumer's config, so it resolves against the producer) — `{name}`,
+`{grain_id}`, `{install_dir}`, etc. all work. One caveat from the filter: since
+the `latest` resolution is gated to selected instances, `{version}`/`{tag}` of a
+producer *not* in the selected subset stay unresolved until a full apply. For
+values outside the placeholder set, use Salt's own jinja in the **pillar**
+(`instance: {{ grains["fqdn"] }}`), which renders before binsvc sees it — pillar
+only, not a bundled `presets/*.yaml` (loaded with `yaml.safe_load`, no jinja).
 
 ## Building blocks (`blocks/*.sls`)
 

--- a/binsvc/tests/test_lib.py
+++ b/binsvc/tests/test_lib.py
@@ -85,8 +85,8 @@ def test_expand_resolves_data_dirs_list_through_install_dir():
 
 def test_merge_globals_overlays_operator_placeholders():
     scope = merge_globals(
-        {"name": "vl_main", "grain_id": "host.example"},
         {"foo": "bar", "dc": "eu-west"},
+        name="vl_main", grain_id="host.example",
     )
     assert scope == {
         "name": "vl_main",
@@ -97,23 +97,20 @@ def test_merge_globals_overlays_operator_placeholders():
 
 
 def test_merge_globals_tolerates_empty_or_none_globals():
-    reserved = {"name": "vl_main"}
-    assert merge_globals(reserved, {}) == reserved
-    assert merge_globals(reserved, None) == reserved
+    assert merge_globals({}, name="vl_main") == {"name": "vl_main"}
+    assert merge_globals(None, name="vl_main") == {"name": "vl_main"}
 
 
 def test_merge_globals_does_not_mutate_inputs():
-    reserved = {"name": "vl_main"}
     global_vars = {"foo": "bar"}
-    merge_globals(reserved, global_vars)
-    assert reserved == {"name": "vl_main"}
+    merge_globals(global_vars, name="vl_main")
     assert global_vars == {"foo": "bar"}
 
 
 def test_merge_globals_fails_loud_on_reserved_collision():
     with pytest.raises(ValueError) as exc:
-        merge_globals({"name": "vl_main", "type": "vlserver"},
-                      {"type": "oops", "name": "nope"})
+        merge_globals({"type": "oops", "name": "nope"},
+                      name="vl_main", type="vlserver")
     # message names the clashing keys so the typo is obvious
     assert "name" in str(exc.value)
     assert "type" in str(exc.value)
@@ -123,7 +120,7 @@ def test_merge_globals_fails_loud_on_phase2_placeholder_collision():
     # a global colliding with a phase-2 name (install_dir/exec/...) would be
     # silently overwritten in the second expand pass, so it must fail loud too.
     with pytest.raises(ValueError) as exc:
-        merge_globals({"name": "vl_main"}, {"install_dir": "/oops"},
+        merge_globals({"install_dir": "/oops"}, name="vl_main",
                       extra_reserved=("install_dir", "exec", "args"))
     assert "install_dir" in str(exc.value)
 


### PR DESCRIPTION
Restructure the main loop into two passes: pass 1 merges and two-phase-expands EVERY instance into a formatted map; pass 2 gathers cross-instance scrape jobs and dispatches the selected subset. The split lets the gather read already- formatted producers, which removes the separate deep_format step scrape configs used to need - scrape is now expanded by the same two-phase pass as every other config, in the producer's own scope. So {name}/{grain_id}/{install_dir}/... work in scrape labels (exporter_node demonstrates {grain_id}).

binsvc:filter now gates the latest resolution (the one network step) and dispatch; merge+format run for all instances so gathering stays correct. Caveat accepted: under a filter, {version}/{tag} of an unselected producer stay unresolved in gathered jobs until a full apply.

merge_globals takes the reserved placeholders as **kwargs instead of a prebuilt dict, so init.sls writes grain identity straight into the call and the HOST_IDENTITY constant is gone. Tests + readme/WHITEPAPER/pillar.example updated.