### PR TITLE
Add OpenBao Salt formula

### DIFF
--- a/openbao/README.md
+++ b/openbao/README.md
@@ -1,0 +1,192 @@
+# openbao Salt formula
+
+Short documentation for this formula.
+
+## Overview
+
+This formula installs and configures OpenBao as a regular systemd service. It is modeled after the existing `vault` formula, but uses OpenBao package releases and the `bao` CLI.
+
+Supported workflow:
+
+- install OpenBao from an official GitHub release `.deb`
+- manage `/etc/openbao/openbao.hcl` and `/etc/openbao/openbao.env`
+- optionally install and initialize local PostgreSQL storage
+- optionally create a self-signed TLS certificate
+- optionally create a static seal key for auto-unseal
+- initialize OpenBao and store init JSON
+- manage audit logging
+- write `/root/.bao-token` for root CLI usage
+- create PostgreSQL database snapshots
+- destructive wipe/reinstall workflow
+
+## Files
+
+- `init.sls` - install, config, TLS/static seal helpers, PostgreSQL setup, systemd service
+- `initialization.sls` - runs `bao operator init`
+- `unseal.sls` - unseal logic for non-auto-unseal deployments
+- `audit.sls` - enable/disable file audit logging
+- `root_token_file.sls` - creates `/root/.bao-token`
+- `remove_init_file.sls` - removes init JSON after recovery material is stored safely
+- `restore.sls` - restore PostgreSQL database dump
+- `wipe.sls` - destructive wipe and reinstall
+- `pillar.example` - single-node PostgreSQL storage example
+
+## Basic Usage
+
+Add an `openbao` pillar based on `openbao/pillar.example`, then apply:
+
+```bash
+salt-ssh 'target' state.apply openbao.init
+salt-ssh 'target' state.apply openbao.initialization
+```
+
+`openbao.initialization` runs only when OpenBao is not initialized. It writes JSON to `/root/openbao-init.json` by default and prints a pillar-ready snippet containing `privileged_token` and `recovery_keys`.
+
+With static seal or another auto-unseal mechanism, keep `init.use_recovery_keys: true`. For non-auto-unseal deployments, set `init.use_recovery_keys: false`; the state will use `key_shares`/`key_threshold` and print `unseal_keys`.
+
+After storing the root token and recovery keys in a safe place, remove the temporary init file:
+
+```bash
+salt-ssh 'target' state.apply openbao.remove_init_file
+```
+
+## Install
+
+By default the formula installs OpenBao `2.6.1` from:
+
+```text
+https://github.com/openbao/openbao/releases/download/v2.6.1/openbao_2.6.1_linux_amd64.deb
+```
+
+Override with:
+
+```yaml
+openbao:
+  version: '2.6.1'
+  package_url: 'https://example.com/openbao_2.6.1_linux_amd64.deb'
+```
+
+## PostgreSQL Storage
+
+For local PostgreSQL managed by this formula:
+
+```yaml
+openbao:
+  postgresql:
+    install: true
+    setup: true
+    user: openbao
+    database: openbao
+    password: XXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+The formula creates or updates the PostgreSQL user and creates the database if missing. The same password must be used in `openbao.config` inside the `storage "postgresql"` block.
+
+## TLS
+
+For lab use, a self-signed certificate can be generated:
+
+```yaml
+openbao:
+  tls:
+    self_signed:
+      enable: true
+      common_name: openbao.example.com
+      subject_alt_name: "DNS:openbao.example.com,DNS:localhost,IP:127.0.0.1"
+```
+
+For production, prefer ACME/corporate CA and point `openbao.config` to the managed certificate/key paths.
+
+## Static Seal
+
+The lab-friendly static seal can be enabled:
+
+```yaml
+openbao:
+  seal:
+    static:
+      enable: true
+      key_file: /etc/openbao/seal/static-unseal.key
+```
+
+The state creates a 32-byte hex key without a newline using `openssl rand -hex 32`.
+
+## Audit Logging
+
+Add:
+
+```yaml
+openbao:
+  audit:
+    enable: true
+    logfile: /var/log/openbao_audit.log
+```
+
+Apply:
+
+```bash
+salt-ssh 'target' state.apply openbao.audit
+```
+
+OpenBao 2.6 manages audit devices declaratively from server config. This state writes `/etc/openbao/audit.hcl` and reloads/restarts OpenBao; it does not call the audit API.
+
+## Root Token File
+
+After initialization, store the root token as `openbao.privileged_token` and apply:
+
+```bash
+salt-ssh 'target' state.apply openbao.root_token_file
+```
+
+This creates `/root/.bao-token` with mode `600`.
+
+## Restore
+
+For PostgreSQL dump restore:
+
+```yaml
+openbao:
+  restore:
+    snapshot_path: /opt/openbao/snapshots/openbao_26-07-24_12-00-00.sql
+```
+
+Apply:
+
+```bash
+salt-ssh 'target' state.apply openbao.restore
+```
+
+The restore state stops OpenBao, recreates the configured PostgreSQL database, loads the SQL dump, and starts OpenBao again.
+
+## Diagnostics
+
+```bash
+bao version
+systemctl status openbao --no-pager
+bao status
+curl --cacert /opt/openbao/tls/tls.crt https://127.0.0.1:8200/v1/sys/health | jq
+cat /etc/openbao/openbao.hcl
+cat /etc/openbao/openbao.env
+```
+
+With a root token:
+
+```bash
+export BAO_ADDR=https://127.0.0.1:8200
+export BAO_CACERT=/opt/openbao/tls/tls.crt
+export BAO_TOKEN="$(cat /root/.bao-token)"
+bao audit list
+bao secrets list
+```
+
+## Backup
+
+Back up at least:
+
+- OpenBao PostgreSQL database
+- `/etc/openbao/openbao.hcl`
+- `/etc/openbao/seal/static-unseal.key` if static seal is used
+- root token and recovery material
+- TLS certificate/key if they are not externally managed
+
+If `openbao.snapshots.enable_postgresql` is true, the formula creates `/opt/openbao/snapshot-postgresql.sh` and schedules it via cron.

--- a/openbao/audit.sls
+++ b/openbao/audit.sls
@@ -1,0 +1,56 @@
+{% if pillar["openbao"] is defined and pillar["openbao"].get("audit") %}
+
+{% set audit_logfile = pillar["openbao"]["audit"].get("logfile", "/var/log/openbao_audit.log") %}
+{% set config_dir = pillar["openbao"].get("config_dir", "/etc/openbao") %}
+{% set audit_path = pillar["openbao"]["audit"].get("path", "file") %}
+
+{% if pillar["openbao"]["audit"].get("enable", False) %}
+
+openbao_audit_file_create:
+  file.managed:
+    - name: {{ audit_logfile }}
+    - user: openbao
+    - group: openbao
+    - mode: 0640
+    - makedirs: True
+    - replace: False
+
+openbao_audit_config:
+  file.managed:
+    - name: {{ config_dir }}/audit.hcl
+    - user: openbao
+    - group: openbao
+    - mode: 0640
+    - contents: |
+        audit "file" "{{ audit_path }}" {
+          description = "OpenBao file audit device"
+          options {
+            file_path = "{{ audit_logfile }}"
+          }
+        }
+    - require:
+      - file: openbao_audit_file_create
+
+openbao_audit_reload:
+  cmd.run:
+    - name: systemctl reload openbao || systemctl restart openbao
+    - onchanges:
+      - file: openbao_audit_config
+    - require:
+      - file: openbao_audit_config
+
+{% else %}
+
+openbao_audit_config_absent:
+  file.absent:
+    - name: {{ config_dir }}/audit.hcl
+
+openbao_audit_reload:
+  cmd.run:
+    - name: systemctl reload openbao || systemctl restart openbao
+    - onchanges:
+      - file: openbao_audit_config_absent
+
+{% endif %}
+
+{% endif %}

--- a/openbao/init.sls
+++ b/openbao/init.sls
@@ -1,0 +1,363 @@
+{% if pillar["openbao"] is defined %}
+
+  {% from "acme/macros.jinja" import verify_and_issue %}
+
+  {% set openbao_version = pillar["openbao"].get("version", "2.6.1") %}
+  {% set openbao_url = pillar["openbao"].get("package_url", "https://github.com/openbao/openbao/releases/download/v" ~ openbao_version ~ "/openbao_" ~ openbao_version ~ "_linux_amd64.deb") %}
+  {% set config_dir = pillar["openbao"].get("config_dir", "/etc/openbao") %}
+  {% set data_dir = pillar["openbao"].get("data_dir", "/opt/openbao/data") %}
+  {% set tls_dir = pillar["openbao"].get("tls", {}).get("dir", "/opt/openbao/tls") %}
+  {% set seal_dir = pillar["openbao"].get("seal", {}).get("dir", config_dir ~ "/seal") %}
+  {% set postgres_cfg = pillar["openbao"].get("postgresql", {}) %}
+  {% set install_postgresql = postgres_cfg.get("install", False) %}
+  {% set setup_postgresql = postgres_cfg.get("setup", False) %}
+  {% set postgresql_user = postgres_cfg.get("user", "openbao") %}
+  {% set postgresql_database = postgres_cfg.get("database", "openbao") %}
+  {% set postgresql_password = postgres_cfg.get("password") %}
+  {% set postgresql_password_file = postgres_cfg.get("password_file", config_dir ~ "/postgres-password") %}
+
+openbao_install_prerequisites:
+  pkg.installed:
+    - refresh: True
+    - reload_modules: True
+    - pkgs:
+        - ca-certificates
+        - curl
+        - jq
+        - openssl
+        - libcap2-bin
+{% if install_postgresql %}
+        - postgresql
+{% endif %}
+
+{% if install_postgresql %}
+openbao_postgresql_service:
+  service.running:
+    - name: postgresql
+    - enable: true
+    - require:
+      - pkg: openbao_install_prerequisites
+{% endif %}
+
+openbao_package_download:
+  cmd.run:
+    - name: curl --fail --location --show-error --output /tmp/openbao_{{ openbao_version }}_linux_amd64.deb {{ openbao_url }}
+    - unless: test -f /tmp/openbao_{{ openbao_version }}_linux_amd64.deb
+    - require:
+      - pkg: openbao_install_prerequisites
+
+openbao_package_install:
+  cmd.run:
+    - name: apt-get install -y /tmp/openbao_{{ openbao_version }}_linux_amd64.deb
+    - unless: bao version 2>/dev/null | grep -q "OpenBao v{{ openbao_version }}"
+    - require:
+      - cmd: openbao_package_download
+
+openbao_group:
+  group.present:
+    - name: openbao
+    - system: True
+    - require:
+      - cmd: openbao_package_install
+
+openbao_user:
+  user.present:
+    - name: openbao
+    - createhome: False
+    - shell: /bin/false
+    - system: True
+    - gid: openbao
+    - require:
+      - group: openbao_group
+
+openbao_config_dir:
+  file.directory:
+    - name: {{ config_dir }}
+    - user: openbao
+    - group: openbao
+    - dir_mode: 750
+    - makedirs: True
+    - require:
+      - user: openbao_user
+
+openbao_home_dirs:
+  file.directory:
+    - names:
+      - /opt/openbao
+      - {{ data_dir }}
+      - /opt/openbao/snapshots
+    - user: openbao
+    - group: openbao
+    - dir_mode: 750
+    - makedirs: True
+    - require:
+      - user: openbao_user
+
+{% if setup_postgresql %}
+{% if postgresql_password is none %}
+openbao_postgresql_password_missing:
+  cmd.run:
+    - name: |
+        echo "ERROR: openbao.postgresql.setup requires openbao.postgresql.password"
+        exit 1
+{% else %}
+openbao_postgresql_password:
+  file.managed:
+    - name: {{ postgresql_password_file }}
+    - mode: 600
+    - user: openbao
+    - group: openbao
+    - contents: |
+        {{ postgresql_password }}
+    - require:
+      - file: openbao_config_dir
+
+openbao_postgresql_user:
+  cmd.run:
+    - name: |
+        su - postgres -c "psql -tAc \"SELECT 1 FROM pg_roles WHERE rolname='{{ postgresql_user }}'\"" | grep -q 1 \
+          && su - postgres -c "psql -c \"ALTER USER {{ postgresql_user }} WITH PASSWORD '{{ postgresql_password }}';\"" \
+          || su - postgres -c "psql -c \"CREATE USER {{ postgresql_user }} WITH PASSWORD '{{ postgresql_password }}';\""
+    - shell: /bin/bash
+    - require:
+{% if install_postgresql %}
+      - service: openbao_postgresql_service
+{% else %}
+      - pkg: openbao_install_prerequisites
+{% endif %}
+
+openbao_postgresql_database:
+  cmd.run:
+    - name: |
+        su - postgres -c "psql -tAc \"SELECT 1 FROM pg_database WHERE datname='{{ postgresql_database }}'\"" | grep -q 1 \
+          || su - postgres -c "createdb -O {{ postgresql_user }} {{ postgresql_database }}"
+    - shell: /bin/bash
+    - require:
+      - cmd: openbao_postgresql_user
+{% endif %}
+{% endif %}
+
+{% if pillar["openbao"].get("tls", {}).get("self_signed", {}).get("enable", False) %}
+  {% set tls_cfg = pillar["openbao"]["tls"]["self_signed"] %}
+  {% set tls_common_name = tls_cfg.get("common_name", grains["fqdn"]) %}
+  {% set tls_san = tls_cfg.get("subject_alt_name", "DNS:" ~ tls_common_name ~ ",DNS:localhost,IP:127.0.0.1") %}
+
+openbao_tls_dir:
+  file.directory:
+    - name: {{ tls_dir }}
+    - user: openbao
+    - group: openbao
+    - dir_mode: 750
+    - makedirs: True
+    - require:
+      - user: openbao_user
+
+openbao_self_signed_tls:
+  cmd.run:
+    - name: openssl req -x509 -newkey rsa:4096 -sha256 -days {{ tls_cfg.get("days", 3650) }} -nodes -keyout {{ tls_dir }}/tls.key -out {{ tls_dir }}/tls.crt -subj "/CN={{ tls_common_name }}" -addext "subjectAltName={{ tls_san }}"
+    - unless: test -s {{ tls_dir }}/tls.crt && test -s {{ tls_dir }}/tls.key && openssl x509 -in {{ tls_dir }}/tls.crt -noout -subject 2>/dev/null | grep -q "CN *= *{{ tls_common_name }}"
+    - require:
+      - file: openbao_tls_dir
+
+openbao_self_signed_tls_permissions:
+  cmd.run:
+    - name: chmod 0640 {{ tls_dir }}/tls.key && chmod 0644 {{ tls_dir }}/tls.crt && chown -R openbao:openbao {{ tls_dir }}
+    - require:
+      - cmd: openbao_self_signed_tls
+{% endif %}
+
+{% if pillar["acme"] is defined and pillar["openbao"].get("acme", {}).get("enable", False) and pillar["openbao"]["acme"].get("domain") is defined %}
+  {% set acme_account = pillar["acme"].keys() | first %}
+
+    {{ verify_and_issue(acme_account, "openbao", pillar["openbao"]["acme"]["domain"]) }}
+
+openbao_cert_permissions:
+  cmd.run:
+    - name: /usr/bin/chown openbao:openbao /opt/acme/cert/openbao_{{ pillar["openbao"]["acme"]["domain"] }}*
+
+openbao_cert_permissions_cron:
+  cron.present:
+    - name: /usr/bin/chown openbao:openbao /opt/acme/cert/openbao_{{ pillar["openbao"]["acme"]["domain"] }}*
+    - identifier: set permissions for openbao certificate
+    - user: root
+    - minute: 0
+{% endif %}
+
+{% if pillar["openbao"].get("seal", {}).get("static", {}).get("enable", False) %}
+  {% set static_key_file = pillar["openbao"]["seal"]["static"].get("key_file", seal_dir ~ "/static-unseal.key") %}
+
+openbao_static_seal_dir:
+  file.directory:
+    - name: {{ seal_dir }}
+    - user: openbao
+    - group: openbao
+    - dir_mode: 750
+    - makedirs: True
+    - require:
+      - file: openbao_config_dir
+
+openbao_static_seal_key:
+  cmd.run:
+    - name: umask 077 && printf "%s" "$(openssl rand -hex 32)" > {{ static_key_file }} && chown openbao:openbao {{ static_key_file }}
+    - unless: test -f {{ static_key_file }} && test "$(wc -c < {{ static_key_file }})" -eq 64
+    - require:
+      - file: openbao_static_seal_dir
+{% endif %}
+
+openbao_config:
+  file.managed:
+    - name: {{ config_dir }}/openbao.hcl
+    - mode: 640
+    - user: openbao
+    - group: openbao
+    - contents: |
+        {{ pillar["openbao"]["config"] | indent(8) }}
+    - require:
+      - file: openbao_config_dir
+
+openbao_env_file:
+  file.managed:
+    - name: {{ config_dir }}/openbao.env
+    - mode: 640
+    - user: openbao
+    - group: openbao
+    - contents: |
+    {%- for var_key, var_val in pillar["openbao"].get("env_vars", {}).items() %}
+        {{ var_key }}={{ var_val }}
+    {%- endfor %}
+    - require:
+      - file: openbao_config_dir
+
+openbao_set_environment:
+  file.replace:
+    - name: /etc/environment
+    - pattern: '^ *BAO_ADDR=.*$'
+    - repl: 'BAO_ADDR={{ pillar["openbao"].get("env_vars", {}).get("BAO_ADDR", "https://127.0.0.1:8200") }}'
+    - append_if_not_found: True
+
+openbao_systemd_override_dir:
+  file.directory:
+    - name: /etc/systemd/system/openbao.service.d
+    - dir_mode: 755
+    - makedirs: True
+
+openbao_systemd_override:
+  file.managed:
+    - name: /etc/systemd/system/openbao.service.d/microdevops.conf
+    - mode: 644
+    - user: root
+    - group: root
+    - contents: |
+        [Service]
+        EnvironmentFile={{ config_dir }}/openbao.env
+        ExecStart=
+        ExecStart=/usr/bin/bao server -config={{ config_dir }}
+        CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE
+        AmbientCapabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE
+        LimitCORE=0
+        LimitMEMLOCK=infinity
+    - require:
+      - file: openbao_systemd_override_dir
+
+openbao_enable_capabilities:
+  cmd.run:
+    - name: setcap cap_ipc_lock,cap_net_bind_service=+ep /usr/bin/bao || true
+    - require:
+      - cmd: openbao_package_install
+
+openbao_systemd_daemon_reload:
+  cmd.run:
+    - name: systemctl daemon-reload
+    - onchanges:
+      - file: openbao_systemd_override
+
+openbao_reset_failed:
+  cmd.run:
+    - name: systemctl reset-failed openbao || true
+    - require:
+      - cmd: openbao_systemd_daemon_reload
+
+openbao_service_enable_and_start:
+  service.running:
+    - name: openbao
+    - enable: true
+    - require:
+      - cmd: openbao_package_install
+      - file: openbao_config
+      - file: openbao_env_file
+      - cmd: openbao_systemd_daemon_reload
+      - cmd: openbao_reset_failed
+{% if setup_postgresql %}
+{% if postgresql_password is none %}
+      - cmd: openbao_postgresql_password_missing
+{% else %}
+      - cmd: openbao_postgresql_database
+{% endif %}
+{% endif %}
+{% if pillar["openbao"].get("tls", {}).get("self_signed", {}).get("enable", False) %}
+      - cmd: openbao_self_signed_tls_permissions
+{% endif %}
+{% if pillar["openbao"].get("seal", {}).get("static", {}).get("enable", False) %}
+      - cmd: openbao_static_seal_key
+{% endif %}
+
+openbao_service_restart:
+  cmd.run:
+    - name: sleep 5; systemctl restart openbao
+    - onchanges:
+      - file: {{ config_dir }}/openbao.hcl
+      - file: {{ config_dir }}/openbao.env
+      - file: /etc/systemd/system/openbao.service.d/microdevops.conf
+      - cmd: openbao_package_install
+{% if pillar["openbao"].get("seal", {}).get("static", {}).get("enable", False) %}
+      - cmd: openbao_static_seal_key
+{% endif %}
+{% if pillar["openbao"].get("tls", {}).get("self_signed", {}).get("enable", False) %}
+      - cmd: openbao_self_signed_tls_permissions
+{% endif %}
+
+{% if pillar["openbao"].get("snapshots", {}).get("enable_postgresql", False) %}
+  {% set snapshots_dir = pillar["openbao"]["snapshots"].get("dir", "/opt/openbao/snapshots") %}
+  {% set cron_minute = pillar["openbao"]["snapshots"].get("cron_minute", range(6, 54) | random) %}
+  {% set cron_hour = pillar["openbao"]["snapshots"].get("cron_hour", "*/4") %}
+  {% set cron_daymonth = pillar["openbao"]["snapshots"].get("cron_daymonth", "*") %}
+  {% set cron_month = pillar["openbao"]["snapshots"].get("cron_month", "*") %}
+  {% set cron_dayweek = pillar["openbao"]["snapshots"].get("cron_dayweek", "*") %}
+
+openbao_create_snapshots_directory:
+  file.directory:
+    - name: {{ snapshots_dir }}
+    - user: openbao
+    - group: openbao
+    - dir_mode: 750
+    - file_mode: 600
+    - makedirs: True
+
+openbao_postgresql_snapshot_script:
+  file.managed:
+    - name: /opt/openbao/snapshot-postgresql.sh
+    - mode: 750
+    - user: root
+    - group: root
+    - contents: |
+        #!/bin/bash
+        set -euo pipefail
+        timestamp=$(date +'%y-%m-%d_%H-%M-%S')
+        snapshots_dir={{ snapshots_dir }}
+        find "$snapshots_dir" -type f -mtime +{{ pillar["openbao"]["snapshots"].get("retention", 7) }} -delete
+        su - postgres -c "pg_dump {{ postgresql_database }}" > "$snapshots_dir/openbao_${timestamp}.sql"
+        chmod 0600 "$snapshots_dir/openbao_${timestamp}.sql"
+
+openbao_postgresql_snapshot_cron:
+  cron.present:
+    - name: /opt/openbao/snapshot-postgresql.sh
+    - identifier: openbao_postgresql_snapshot
+    - minute: '{{ cron_minute }}'
+    - hour: '{{ cron_hour }}'
+    - daymonth: '{{ cron_daymonth }}'
+    - month: '{{ cron_month }}'
+    - dayweek: '{{ cron_dayweek }}'
+    - user: root
+{% endif %}
+
+{% endif %}

--- a/openbao/initialization.sls
+++ b/openbao/initialization.sls
@@ -1,0 +1,65 @@
+{% if pillar["openbao"] is defined %}
+
+{% set init_cfg = pillar["openbao"].get("init", {}) %}
+{% set use_recovery_keys = init_cfg.get("use_recovery_keys", True) %}
+{% set key_shares = init_cfg.get("key_shares", 5) %}
+{% set key_threshold = init_cfg.get("key_threshold", 3) %}
+{% set recovery_shares = init_cfg.get("recovery_shares", 1) %}
+{% set recovery_threshold = init_cfg.get("recovery_threshold", 1) %}
+{% set init_file = init_cfg.get("output_file", "/root/openbao-init.json") %}
+{% set bao_addr = pillar["openbao"].get("env_vars", {}).get("BAO_ADDR", "https://127.0.0.1:8200") %}
+{% set bao_cacert = pillar["openbao"].get("env_vars", {}).get("BAO_CACERT", "/opt/openbao/tls/tls.crt") %}
+
+openbao_operator_init:
+  cmd.run:
+{% if use_recovery_keys %}
+    - name: bao operator init -recovery-shares={{ recovery_shares }} -recovery-threshold={{ recovery_threshold }} -format=json > {{ init_file }}
+{% else %}
+    - name: bao operator init -key-shares={{ key_shares }} -key-threshold={{ key_threshold }} -format=json > {{ init_file }}
+{% endif %}
+    - unless: bao status -format=json 2>/dev/null | jq -e '.initialized == true'
+    - env:
+      - BAO_ADDR: "{{ bao_addr }}"
+      - BAO_CACERT: "{{ bao_cacert }}"
+    - shell: /bin/bash
+
+openbao_init_file_permissions:
+  cmd.run:
+    - name: chmod 0600 {{ init_file }} && chown root:root {{ init_file }}
+    - onlyif: test -f {{ init_file }}
+    - require:
+      - cmd: openbao_operator_init
+
+openbao_init_show:
+  cmd.run:
+    - name: |
+        python3 << 'EOF'
+        import json
+
+        with open('{{ init_file }}', 'r') as f:
+            init_data = json.load(f)
+
+        root_token = init_data.get('root_token', '')
+        recovery_keys = init_data.get('recovery_keys_b64', [])
+        unseal_keys = init_data.get('unseal_keys_b64', [])
+
+        print("\n" + "="*60)
+        print("ADD THIS TO YOUR OPENBAO PILLAR:")
+        print("="*60)
+        print("openbao:")
+        print("  privileged_token: '{}'".format(root_token))
+        if recovery_keys:
+            print("  recovery_keys:")
+            for key in recovery_keys:
+                print("    - '{}'".format(key))
+        if unseal_keys:
+            print("  unseal_keys:")
+            for key in unseal_keys:
+                print("    - '{}'".format(key))
+        print("="*60)
+        EOF
+    - onlyif: test -f {{ init_file }}
+    - require:
+      - cmd: openbao_init_file_permissions
+
+{% endif %}

--- a/openbao/pillar.example
+++ b/openbao/pillar.example
@@ -1,0 +1,70 @@
+{%
+set openbao_db_password = 'XXXXXXXXXXXXXXXXXXXXXXXX'
+%}
+
+openbao:
+  version: '2.6.1'
+  privileged_token: 'hvs.XXXXXXXXXXXXXXXXXXXXXXXX'
+  recovery_keys:
+    - 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+  env_vars:
+    BAO_ADDR: "https://{{ grains['fqdn'] }}:8200"
+    BAO_CACERT: "/opt/openbao/tls/tls.crt"
+  init:
+    use_recovery_keys: true
+    recovery_shares: 1
+    recovery_threshold: 1
+    output_file: /root/openbao-init.json
+  postgresql:
+    install: true
+    setup: true
+    user: openbao
+    database: openbao
+    password: {{ openbao_db_password }}
+    password_file: /etc/openbao/postgres-password
+  tls:
+    self_signed:
+      enable: true
+      common_name: {{ grains['fqdn'] }}
+      subject_alt_name: "DNS:{{ grains['fqdn'] }},DNS:localhost,IP:127.0.0.1"
+      days: 3650
+  seal:
+    static:
+      enable: true
+      key_file: /etc/openbao/seal/static-unseal.key
+  snapshots:
+    enable_postgresql: true
+    retention: 7
+  audit:
+    enable: true
+    logfile: /var/log/openbao_audit.log
+  config: |
+    ui = true
+    api_addr = "https://{{ grains['fqdn'] }}:8200"
+    cluster_addr = "https://{{ grains['fqdn'] }}:8201"
+
+    storage "postgresql" {
+      connection_url = "postgres://openbao:{{ openbao_db_password }}@127.0.0.1:5432/openbao?sslmode=disable"
+      table = "openbao_kv_store"
+      ha_enabled = "true"
+      ha_table = "openbao_ha_locks"
+    }
+
+    listener "tcp" {
+      address = "0.0.0.0:8200"
+      tls_cert_file = "/opt/openbao/tls/tls.crt"
+      tls_key_file = "/opt/openbao/tls/tls.key"
+      telemetry {
+        unauthenticated_metrics_access = true
+      }
+    }
+
+    seal "static" {
+      current_key_id = "static-unseal-0"
+      current_key = "file:///etc/openbao/seal/static-unseal.key"
+    }
+
+    telemetry {
+      disable_hostname = true
+      prometheus_retention_time = "12h"
+    }

--- a/openbao/remove_init_file.sls
+++ b/openbao/remove_init_file.sls
@@ -1,0 +1,9 @@
+{% if pillar["openbao"] is defined %}
+
+{% set init_file = pillar["openbao"].get("init", {}).get("output_file", "/root/openbao-init.json") %}
+
+openbao_remove_init_file:
+  file.absent:
+    - name: {{ init_file }}
+
+{% endif %}

--- a/openbao/restore.sls
+++ b/openbao/restore.sls
@@ -1,0 +1,51 @@
+{% if pillar["openbao"] is defined and pillar["openbao"].get("restore") %}
+
+{% set restore_cfg = pillar["openbao"]["restore"] %}
+{% set snapshot_path = restore_cfg.get("snapshot_path") %}
+{% set postgres_cfg = pillar["openbao"].get("postgresql", {}) %}
+{% set postgresql_database = postgres_cfg.get("database", "openbao") %}
+{% set postgresql_user = postgres_cfg.get("user", "openbao") %}
+
+openbao_restore_pillar_missing:
+  cmd.run:
+    - name: |
+        echo "ERROR: openbao.restore requires openbao.restore.snapshot_path"
+        exit 1
+    - onlyif: test -z "{{ snapshot_path }}"
+
+{% if snapshot_path %}
+openbao_restore_stop:
+  service.dead:
+    - name: openbao
+
+openbao_restore_drop_database:
+  cmd.run:
+    - name: |
+        su - postgres -c "psql -d postgres -c \"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname='{{ postgresql_database }}';\""
+        su - postgres -c "dropdb --if-exists {{ postgresql_database }}"
+    - shell: /bin/bash
+    - require:
+      - service: openbao_restore_stop
+
+openbao_restore_create_database:
+  cmd.run:
+    - name: su - postgres -c "createdb -O {{ postgresql_user }} {{ postgresql_database }}"
+    - require:
+      - cmd: openbao_restore_drop_database
+
+openbao_restore_load_database:
+  cmd.run:
+    - name: su - postgres -c "psql {{ postgresql_database }}" < {{ snapshot_path }}
+    - shell: /bin/bash
+    - require:
+      - cmd: openbao_restore_create_database
+
+openbao_restore_start:
+  service.running:
+    - name: openbao
+    - enable: true
+    - require:
+      - cmd: openbao_restore_load_database
+{% endif %}
+
+{% endif %}

--- a/openbao/root_token_file.sls
+++ b/openbao/root_token_file.sls
@@ -1,0 +1,12 @@
+{% if pillar["openbao"] is defined and pillar["openbao"].get("privileged_token") is defined %}
+
+openbao_root_token_file:
+  file.managed:
+    - name: /root/.bao-token
+    - mode: 600
+    - user: root
+    - group: root
+    - contents: |
+        {{ pillar["openbao"]["privileged_token"] | indent(8) }}
+
+{% endif %}

--- a/openbao/unseal.sls
+++ b/openbao/unseal.sls
@@ -1,0 +1,17 @@
+{% if pillar["openbao"] is defined and pillar["openbao"].get("unseal_keys") %}
+
+{% set bao_addr = pillar["openbao"].get("env_vars", {}).get("BAO_ADDR", "https://127.0.0.1:8200") %}
+{% set bao_cacert = pillar["openbao"].get("env_vars", {}).get("BAO_CACERT", "/opt/openbao/tls/tls.crt") %}
+
+{% for key in pillar["openbao"]["unseal_keys"] %}
+openbao_unseal_{{ loop.index }}:
+  cmd.run:
+    - name: bao operator unseal {{ key }}
+    - shell: /bin/bash
+    - env:
+      - BAO_ADDR: "{{ bao_addr }}"
+      - BAO_CACERT: "{{ bao_cacert }}"
+    - onlyif: bao status | grep "Sealed" | grep -q "true"
+{% endfor %}
+
+{% endif %}

--- a/openbao/wipe.sls
+++ b/openbao/wipe.sls
@@ -1,0 +1,31 @@
+{% if pillar["openbao"] is defined %}
+
+{% set config_dir = pillar["openbao"].get("config_dir", "/etc/openbao") %}
+{% set data_dir = pillar["openbao"].get("data_dir", "/opt/openbao/data") %}
+{% set default_paths = [data_dir, "/opt/openbao/snapshots"] %}
+{% set wipe_paths = pillar["openbao"].get("wipe", {}).get("paths", default_paths) %}
+
+openbao_wipe_stop:
+  service.dead:
+    - name: openbao
+
+{% for p in wipe_paths %}
+openbao_remove_path_{{ loop.index }}:
+  cmd.run:
+    - name: rm -rf {{ p }}
+    - onlyif: test -e {{ p }}
+    - require:
+      - service: openbao_wipe_stop
+{% endfor %}
+
+openbao_purge_package:
+  pkg.purged:
+    - name: openbao
+    - require:
+      - service: openbao_wipe_stop
+
+include:
+  - openbao.init
+  - openbao.initialization
+
+{% endif %}


### PR DESCRIPTION
## Summary

  Add a new `openbao` Salt formula modeled after the existing `vault` formula.

  The formula supports:

  - OpenBao `.deb` installation from GitHub releases
  - systemd service setup
  - PostgreSQL storage setup
  - self-signed TLS generation
  - static seal key generation
  - initialization workflow
  - declarative audit device config
  - root token file helper
  - unseal, restore, wipe, and PostgreSQL snapshot helpers